### PR TITLE
Timestamp indexing

### DIFF
--- a/examples/evaluators/golang/simple/main.go
+++ b/examples/evaluators/golang/simple/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	fmt.Println("overloadedPlayers")
 	pretty.PrettyPrint(overloadedPlayers)
-	fmt.Println("overloadePlayerList")
+	fmt.Println("overloadedPlayerList")
 	pretty.PrettyPrint(overloadedPlayerList)
 	fmt.Println("overloadedMatchList")
 	pretty.PrettyPrint(overloadedMatchList)


### PR DESCRIPTION
Add timestamp indexing and de-indexing as a first class index for all match requests.

To use the timestamp index, match functions can us ZRANGE now to better segment filters. The short-term goal is to allow for the simplest way to run the same function multiple times at once.

I didn't debate the name too long, so we can come up with something more descriptive if there are good ideas. I didn't think _starttime_, _qtime_, _createddate_ or any of the other db-toned names fit once you move into the match function context.