### PR TITLE
Add redis auth and move connection to redishelpers

### DIFF
--- a/cmd/frontendapi/main.go
+++ b/cmd/frontendapi/main.go
@@ -25,13 +25,12 @@ import (
 	"errors"
 	"os"
 	"os/signal"
-	"time"
 
 	"github.com/GoogleCloudPlatform/open-match/cmd/frontendapi/apisrv"
 	"github.com/GoogleCloudPlatform/open-match/config"
 	"github.com/GoogleCloudPlatform/open-match/internal/metrics"
+	redishelpers "github.com/GoogleCloudPlatform/open-match/internal/statestorage/redis"
 
-	"github.com/gomodule/redigo/redis"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"go.opencensus.io/plugin/ocgrpc"
@@ -85,7 +84,7 @@ func init() {
 func main() {
 
 	// Connect to redis
-	pool := redisConnect(cfg)
+	pool := redishelpers.ConnectionPool(cfg)
 	defer pool.Close()
 
 	// Instantiate the gRPC server with the connections we've made
@@ -103,27 +102,4 @@ func main() {
 	signal.Notify(terminate, os.Interrupt)
 	<-terminate
 	feLog.Info("Shutting down gRPC server")
-}
-
-// redisConnect reads the configuration and attempts to instantiate a redis connection
-// pool based on the configured hostname and port.
-// TODO: needs to be reworked to use redis sentinel when we're ready to support it.
-func redisConnect(cfg *viper.Viper) *redis.Pool {
-
-	// As per https://www.iana.org/assignments/uri-schemes/prov/redis
-	// redis://user:secret@localhost:6379/0?foo=bar&qux=baz
-	redisURL := "redis://" + cfg.GetString("redis.hostname") + ":" + cfg.GetString("redis.port")
-	// TODO: check if auth details are in the config, and append them if they
-	// are.  Right now, assumes your redis instance is unsecured!
-
-	feLog.WithFields(log.Fields{"redisURL": redisURL}).Info("Attempting to connect to Redis")
-	pool := redis.Pool{
-		MaxIdle:     3,
-		MaxActive:   0,
-		IdleTimeout: 60 * time.Second,
-		Dial:        func() (redis.Conn, error) { return redis.DialURL(redisURL) },
-	}
-
-	feLog.Info("Connected to Redis")
-	return &pool
 }

--- a/config/config.go
+++ b/config/config.go
@@ -43,9 +43,12 @@ var (
 	// REDIS_SENTINEL_PORT_6379_TCP_PROTO=tcp
 	// REDIS_SENTINEL_SERVICE_HOST=10.55.253.195
 	envMappings = map[string]string{
-		"redis.hostname": "REDIS_SENTINEL_SERVICE_HOST",
-		"redis.port":     "REDIS_SENTINEL_SERVICE_PORT",
-		"debug":          "DEBUG",
+		"redis.hostname":         "REDIS_SENTINEL_SERVICE_HOST",
+		"redis.port":             "REDIS_SENTINEL_SERVICE_PORT",
+		"redis.pool.maxIdle":     "REDIS_POOL_MAXIDLE",
+		"redis.pool.maxActive":   "REDIS_POOL_MAXACTIVE",
+		"redis.pool.idleTimeout": "REDIS_POOL_IDLETIMEOUT",
+		"debug":                  "DEBUG",
 	}
 
 	// Viper config management setup

--- a/config/matchmaker_config.json
+++ b/config/matchmaker_config.json
@@ -34,7 +34,12 @@
     },
     "redis": {
         "user": "",
-        "password": ""
+        "password": "",
+        "pool" : {
+            "maxIdle" : 3,
+            "maxActive" : 0,
+            "idleTimeout" : 60
+        }
     },
     "jsonkeys": {
         "mmfImages": "imagename",

--- a/config/matchmaker_config.json
+++ b/config/matchmaker_config.json
@@ -1,5 +1,5 @@
 {
-    "debug": true, 
+    "debug": true,
     "api": {
         "backend": {
             "port": 50505
@@ -32,9 +32,13 @@
             "tag": "dev"
         }
     },
+    "redis": {
+        "user": "",
+        "password": ""
+    },
     "jsonkeys": {
-        "mmfImages": "imagename", 
-        "roster": "profile.roster", 
+        "mmfImages": "imagename",
+        "roster": "profile.roster",
         "connstring": "connstring"
     },
     "interval": {

--- a/internal/statestorage/redis/redishelpers.go
+++ b/internal/statestorage/redis/redishelpers.go
@@ -56,9 +56,9 @@ func ConnectionPool(cfg *viper.Viper) *redis.Pool {
 
 	rhLog.WithFields(log.Fields{"redisURL": redisURL}).Debug("Attempting to connect to Redis")
 	pool := redis.Pool{
-		MaxIdle:     3,
-		MaxActive:   0,
-		IdleTimeout: 60 * time.Second,
+		MaxIdle:     cfg.GetInt("redis.pool.maxIdle"),
+		MaxActive:   cfg.GetInt("redis.pool.maxActive"),
+		IdleTimeout: cfg.GetDuration("redis.pool.idleTimeout") * time.Second,
 		Dial:        func() (redis.Conn, error) { return redis.DialURL(redisURL) },
 	}
 


### PR DESCRIPTION
Changes proposed

- Add support for redis authentication. Currently it assumes the keys for `redis.user` and `redis.password` are set in `matchmaker_config.json`. If this needs to be moved to look at env vars or similar, can do.

- Refactored redis connection pool to live in `redishelpers` (avoids duplication) and updated `backendapi`, `frontendapi`, and `mmforc` entry points to use this helper method.

- Misc clean up, such as; removed unreferenced packages and removed trailing whitespace.