### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,8 @@ Open Match uses [OpenCensus](https://opencensus.io/) for metrics instrumentation
 
 ### Redis setup
 
-By default, Open Match expects you to run Redis *somewhere*. `Host:port` connection information can be put in the config file for any Redis instance reachable from the [Kubernetes namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/). By default, Open Match sensibly runs in the Kubernetes `default` namespace. In most instances, we expect users will run a copy of Redis in a pod in Kubernetes, with a service pointing to it.
+By default, Open Match expects you to run Redis *somewhere*. Connection information can be put in the config file (`matchmaker_config.json`) for any Redis instance reachable from the [Kubernetes namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/). By default, Open Match sensibly runs in the Kubernetes `default` namespace. In most instances, we expect users will run a copy of Redis in a pod in Kubernetes, with a service pointing to it.
 
-* Basic auth for Redis instances isn't implemented, but is trivial to implement.
 * HA configurations for Redis aren't implemented by the provided Kubernetes resource definition files, but Open Match expects the Redis service to be named `redis-sentinel`, which provides an easier path to multi-instance deployments.
 
 ## Additional examples

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Open Match is a set of processes designed to run on Kubernetes. It contains thes
 1. Backend API
 1. Matchmaker Function Orchestrator (MMFOrc)
 
-It also explicitly depends on these two **customizable** components.  
+It also explicitly depends on these two **customizable** components.
 
 1. Matchmaking "Function" (MMF)
 1. Evaluator
@@ -96,7 +96,7 @@ Matchmaking Functions (MMFs) are run by the Matchmaker Function Orchestrator (MM
 1. Remove the players it selected from consideration by other MMFs.
 1. (Optional, but recommended) Export stats for metrics collection.
 
-Example MMFs are provided in Golang and C#. 
+Example MMFs are provided in Golang and C#.
 
 ## Open Source Software integrations
 
@@ -108,7 +108,7 @@ Logging for Open Match uses the [Golang logrus module](https://github.com/sirups
 
 Open Match uses [OpenCensus](https://opencensus.io/) for metrics instrumentation. The [gRPC](https://grpc.io/) integrations are built-in, and Golang redigo module integrations are incoming, but [haven't been merged into the official repo](https://github.com/opencensus-integrations/redigo/pull/1). All of the core components expose HTTP `/metrics` endpoints on the port defined in `config/matchmaker_config.json` (default: 9555) for Prometheus to scrape. If you would like to export to a different metrics aggregation platform, we suggest you have a look at the OpenCensus documentation &mdash; there may be one written for you already, and switching to it may be as simple as changing a few lines of code.
 
-**Note:** A standard for instrumentation of MMFs is planned.  
+**Note:** A standard for instrumentation of MMFs is planned.
 
 ### Redis setup
 
@@ -123,7 +123,7 @@ By default, Open Match expects you to run Redis *somewhere*. `Host:port` connect
 
 The following examples of how to call the APIs are provided in the repository. Both have associated `Dockerfile`s and `cloudbuild_COMPONENT.yaml` files:
 
-* `frontendstub/main.go` calls the Frontend API continually, putting players into the queue with simulated latencies from major metropolitan cities. 
+* `frontendstub/main.go` calls the Frontend API continually, putting players into the queue with simulated latencies from major metropolitan cities.
 * `backendstub/main.go` calls the Backend API and passes in the profile found in `backendstub/profiles/testprofile.json` to the `ListMatches` API endpoint, then prints the results.
 
 ## Usage
@@ -142,7 +142,7 @@ All the core components for Open Match are written in Golang and use the [Docker
 
 ## Configuration
 
-Currently, each component reads a local config file `matchmaker_config.json`, and all components assume they have the same configuration. To this end, there is a single centralized config file located in the `<REPO_ROOT>/config/` which is symlinked to each component's subdirectory for convenience when building locally. When `docker build`ing the component container images, the Dockerfile copies the centralized config file into the component directory. 
+Currently, each component reads a local config file `matchmaker_config.json`, and all components assume they have the same configuration. To this end, there is a single centralized config file located in the `<REPO_ROOT>/config/` which is symlinked to each component's subdirectory for convenience when building locally. When `docker build`ing the component container images, the Dockerfile copies the centralized config file into the component directory.
 
 We plan to replace this with a Kubernetes-managed config with dynamic reloading when development time allows. Pull requests are welcome!
 
@@ -191,7 +191,7 @@ Apache 2.0
 # Missing functionality
 
 * Player/Group records generated when a client enters the matchmaking pool need to be removed after a certain amount of time with no activity. When using Redis, this will be implemented as a expiration on the player record.
-* Instrumentation of MMFs is in the planning stages.  Since MMFs are by design meant to be completely customizable (to the point of allowing any process that can be packaged in a Docker container), metrics/stats will need to have an expected format and formalized outgoing pathway.  Currently the thought is that it might be that the metrics should be written to a particular key in statestorage in a format compatible with opencensus, and will be collected, aggreggated, and exported to Prometheus using another process. 
+* Instrumentation of MMFs is in the planning stages.  Since MMFs are by design meant to be completely customizable (to the point of allowing any process that can be packaged in a Docker container), metrics/stats will need to have an expected format and formalized outgoing pathway.  Currently the thought is that it might be that the metrics should be written to a particular key in statestorage in a format compatible with opencensus, and will be collected, aggreggated, and exported to Prometheus using another process.
 * The Kubernetes service account used by the MMFOrc should be updated to have min required permissions.
 * Autoscaling isn't turned on for the Frontend or Backend API Kubernetes deployments by default.
 * Match profiles should be able to define multiple MMF container images to run, but this is not currently supported. This enables A/B testing and several other scenarios.

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,21 +32,21 @@ gcloud compute zones list
 
 ## Configuration
 
-Currently, each component reads a local config file `matchmaker_config.json` , and all components assume they have the same configuration.  To this end, there is a single centralized config file located in the `<REPO_ROOT>/config/` which is symlinked to each component's subdirectory for convenience when building locally. 
+Currently, each component reads a local config file `matchmaker_config.json` , and all components assume they have the same configuration.  To this end, there is a single centralized config file located in the `<REPO_ROOT>/config/` which is symlinked to each component's subdirectory for convenience when building locally.
 
 **NOTE** 'defaultImages' container images names in the config file will need to be updated with **your container registry URI**.  Here's an example command in Linux to do this (just replace YOUR_REGISTRY_URI with the appropriate location in your environment, should be run from the config directory):
 ```
-sed -i 's|gcr.io/matchmaker-dev-201405|YOUR_REGISTRY_URI|g' matchamker_config.json 
+sed -i 's|gcr.io/matchmaker-dev-201405|YOUR_REGISTRY_URI|g' matchmaker_config.json
 ```
 For MacOS the `-i` flag creates backup files when changing the original file in place. You can use the following command, and then delete the `*.backup` files afterwards if you don't need them anymore:
 ```
-sed -i'.backup' -e 's|gcr.io/matchmaker-dev-201405|YOUR_REGISTRY_URI|g' matchamker_config.json 
+sed -i'.backup' -e 's|gcr.io/matchmaker-dev-201405|YOUR_REGISTRY_URI|g' matchmaker_config.json
 ```
-If you are using the gcr.io registry on GCP, the default URI is `gcr.io/<PROJECT_NAME>`. 
+If you are using the gcr.io registry on GCP, the default URI is `gcr.io/<PROJECT_NAME>`.
 
 We plan to replace this with a Kubernetes-managed config with dynamic reloading when development time allows.  Pull requests are welcome!
 
-## Running Open Match in a development environment 
+## Running Open Match in a development environment
 
 The rest of this guide assumes you have a cluster (example is using GKE, but works on any cluster with a little tweaking), and kubectl configured to administer that cluster, and you've built all the Docker container images described by `Dockerfiles` in the repository root directory and given them the docker tag 'dev'.  It assumes you are in the `<REPO_ROOT>/deployments/k8s/` directory.
 
@@ -58,14 +58,14 @@ For MacOS the `-i` flag creates backup files when changing the original file in 
 ```
 sed -i'.backup' -e 's|gcr.io/matchmaker-dev-201405|YOUR_REGISTRY_URI|g' *deployment.json
 ```
-If you are using the gcr.io registry on GCP, the default URI is `gcr.io/<PROJECT_NAME>`. 
+If you are using the gcr.io registry on GCP, the default URI is `gcr.io/<PROJECT_NAME>`.
 
 * Start a copy of redis and a service in front of it:
 ```
 kubectl apply -f redis_deployment.json
 kubectl apply -f redis_service.json
 ```
-* Run the **core components**: the frontend API, the backend API, and the matchmaker function orchestrator (MMFOrc). 
+* Run the **core components**: the frontend API, the backend API, and the matchmaker function orchestrator (MMFOrc).
 **NOTE** In order to kick off jobs, the matchmaker function orchestrator needs a service account with permission to administer the cluster. This should be updated to have min required perms before launch, this is pretty permissive but acceptable for closed testing:
 ```
 kubectl apply -f backendapi_deployment.json

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,1 +1,1 @@
-*"I notice that all the APIs use gRPC. What if I want to make my calls using REST, or via a Websocket?"** (gateway/proxy OSS projects are available) 
+*"I notice that all the APIs use gRPC. What if I want to make my calls using REST, or via a Websocket?"** (gateway/proxy OSS projects are available)


### PR DESCRIPTION
Misc documentation fixes.

I also updated the section about redis connection details and removed the note about redis auth since that was implemented in https://github.com/GoogleCloudPlatform/open-match/pull/26.