### PR TITLE
Add logging config to support json and level selection for logrus

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Example MMFs are provided in Golang and C#.
 
 ### Structured logging
 
-Logging for Open Match uses the [Golang logrus module](https://github.com/sirupsen/logrus) to provide structured logs. Logs are output to `stdout` in each component, as expected by Docker and Kubernetes. If you have a specific log aggregator as your final destination, we recommend you have a look at the logrus documentation as there is probably a log formatter that plays nicely with your stack.
+Logging for Open Match uses the [Golang logrus module](https://github.com/sirupsen/logrus) to provide structured logs. Logs are output to `stdout` in each component, as expected by Docker and Kubernetes. Level and format are configurable via config/matchmaker_config.json. If you have a specific log aggregator as your final destination, we recommend you have a look at the logrus documentation as there is probably a log formatter that plays nicely with your stack. If you 
 
 ### Instrumentation for metrics
 
@@ -138,6 +138,15 @@ Once we reach a 1.0 release, we plan to produce publicly available (Linux) Docke
 All components of Open Match produce (Linux) Docker container images as artifacts, and there are included `Dockerfile`s for each. [Google Cloud Platform Cloud Build](https://cloud.google.com/cloud-build/docs/) users will also find `cloudbuild_COMPONENT.yaml` files for each component in the repository root.
 
 All the core components for Open Match are written in Golang and use the [Dockerfile multistage builder pattern](https://docs.docker.com/develop/develop-images/multistage-build/). This pattern uses intermediate Docker containers as a Golang build environment while producing lightweight, minimized container images as final build artifacts. When the project is ready for production, we will modify the `Dockerfile`s to uncomment the last build stage. Although this pattern is great for production container images, it removes most of the utilities required to troubleshoot issues during development.
+
+### Example compiling components
+```
+docker build -t openmatch-backendapi -f Dockerfile.backendapi .
+docker build -t openmatch-frontendapi -f Dockerfile.frontendapi .
+docker build -t openmatch-mmforc -f Dockerfile.mmforc .
+docker build -t openmatch-evaluator -f Dockerfile.evaluator .
+docker build -t openmatch-mmf -f Dockerfile.mmf .
+```
 
 ## Configuration
 

--- a/cmd/backendapi/main.go
+++ b/cmd/backendapi/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/open-match/cmd/backendapi/apisrv"
 	"github.com/GoogleCloudPlatform/open-match/config"
+	"github.com/GoogleCloudPlatform/open-match/internal/logging"
 	"github.com/GoogleCloudPlatform/open-match/internal/metrics"
 	redishelpers "github.com/GoogleCloudPlatform/open-match/internal/statestorage/redis"
 
@@ -51,7 +52,6 @@ var (
 )
 
 func init() {
-	// Logrus structured logging initialization
 	// Add a hook to the logger to auto-count log lines for metrics output thru OpenCensus
 	log.AddHook(metrics.NewHook(apisrv.BeLogLines, apisrv.KeySeverity))
 
@@ -63,10 +63,8 @@ func init() {
 		}).Error("Unable to load config file")
 	}
 
-	if cfg.GetBool("debug") == true {
-		log.SetLevel(log.DebugLevel) // debug only, verbose - turn off in production!
-		beLog.Warn("Debug logging configured. Not recommended for production!")
-	}
+	// Configure open match logging defaults
+	logging.ConfigureLogging(cfg)
 
 	// Configure OpenCensus exporter to Prometheus
 	// metrics.ConfigureOpenCensusPrometheusExporter expects that every OpenCensus view you

--- a/cmd/frontendapi/main.go
+++ b/cmd/frontendapi/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/open-match/cmd/frontendapi/apisrv"
 	"github.com/GoogleCloudPlatform/open-match/config"
+	"github.com/GoogleCloudPlatform/open-match/internal/logging"
 	"github.com/GoogleCloudPlatform/open-match/internal/metrics"
 	redishelpers "github.com/GoogleCloudPlatform/open-match/internal/statestorage/redis"
 
@@ -51,7 +52,6 @@ var (
 )
 
 func init() {
-	// Logrus structured logging initialization
 	// Add a hook to the logger to auto-count log lines for metrics output thru OpenCensus
 	log.AddHook(metrics.NewHook(apisrv.FeLogLines, apisrv.KeySeverity))
 
@@ -63,10 +63,8 @@ func init() {
 		}).Error("Unable to load config file")
 	}
 
-	if cfg.GetBool("debug") == true {
-		log.SetLevel(log.DebugLevel) // debug only, verbose - turn off in production!
-		feLog.Warn("Debug logging configured. Not recommended for production!")
-	}
+	// Configure open match logging defaults
+	logging.ConfigureLogging(cfg)
 
 	// Configure OpenCensus exporter to Prometheus
 	// metrics.ConfigureOpenCensusPrometheusExporter expects that every OpenCensus view you

--- a/cmd/mmforc/main.go
+++ b/cmd/mmforc/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/open-match/config"
+	"github.com/GoogleCloudPlatform/open-match/internal/logging"
 	"github.com/GoogleCloudPlatform/open-match/internal/metrics"
 	redisHelpers "github.com/GoogleCloudPlatform/open-match/internal/statestorage/redis"
 	"github.com/tidwall/gjson"
@@ -64,9 +65,7 @@ var (
 )
 
 func init() {
-	// Logrus structured logging initialization
 	// Add a hook to the logger to auto-count log lines for metrics output thru OpenCensus
-	log.SetFormatter(&log.JSONFormatter{})
 	log.AddHook(metrics.NewHook(MmforcLogLines, KeySeverity))
 
 	// Viper config management initialization
@@ -77,10 +76,8 @@ func init() {
 		}).Error("Unable to load config file")
 	}
 
-	if cfg.GetBool("debug") == true {
-		log.SetLevel(log.DebugLevel) // debug only, verbose - turn off in production!
-		mmforcLog.Warn("Debug logging configured. Not recommended for production!")
-	}
+	// Configure open match logging defaults
+	logging.ConfigureLogging(cfg)
 
 	// Configure OpenCensus exporter to Prometheus
 	// metrics.ConfigureOpenCensusPrometheusExporter expects that every OpenCensus view you

--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,6 @@ var (
 		"redis.pool.maxIdle":     "REDIS_POOL_MAXIDLE",
 		"redis.pool.maxActive":   "REDIS_POOL_MAXACTIVE",
 		"redis.pool.idleTimeout": "REDIS_POOL_IDLETIMEOUT",
-		"debug":                  "DEBUG",
 	}
 
 	// Viper config management setup

--- a/config/matchmaker_config.json
+++ b/config/matchmaker_config.json
@@ -1,5 +1,9 @@
 {
     "debug": true,
+    "logging":{
+        "level": "debug",
+        "format": "json"
+    },
     "api": {
         "backend": {
             "port": 50505

--- a/internal/logging/helper.go
+++ b/internal/logging/helper.go
@@ -1,0 +1,36 @@
+package logging
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// ConfigureLogging sets up open match logging using the logging section of the matchmaker_config.json
+// This includes formatting (text[default] or json) and
+// logging levels (debug, info [default], warn, error, fatal, panic)
+func ConfigureLogging(cfg *viper.Viper) {
+	switch cfg.GetString("logging.format") {
+	case "json":
+		logrus.SetFormatter(&logrus.JSONFormatter{})
+	case "text":
+	default:
+		logrus.SetFormatter(&logrus.TextFormatter{})
+	}
+
+	switch cfg.GetString("logging.level") {
+	case "debug":
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.Warn("Debug logging level configured. Not recommended for production!")
+	case "warn":
+		logrus.SetLevel(logrus.WarnLevel)
+	case "error":
+		logrus.SetLevel(logrus.ErrorLevel)
+	case "fatal":
+		logrus.SetLevel(logrus.FatalLevel)
+	case "panic":
+		logrus.SetLevel(logrus.PanicLevel)
+	case "info":
+	default:
+		logrus.SetLevel(logrus.InfoLevel)
+	}
+}


### PR DESCRIPTION
Adds a simple log config section in matchmaker_config.json to add level selection and format selection (text or json). This change also adds a logging package that's now being called from each of the components' inits to configure logging once when each process starts.