### PR TITLE
Optional Redis HA deployment for #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Open Match uses [OpenCensus](https://opencensus.io/) for metrics instrumentation
 
 By default, Open Match expects you to run Redis *somewhere*. Connection information can be put in the config file (`matchmaker_config.json`) for any Redis instance reachable from the [Kubernetes namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/). By default, Open Match sensibly runs in the Kubernetes `default` namespace. In most instances, we expect users will run a copy of Redis in a pod in Kubernetes, with a service pointing to it.
 
-* HA configurations for Redis aren't implemented by the provided Kubernetes resource definition files, but Open Match expects the Redis service to be named `redis-sentinel`, which provides an easier path to multi-instance deployments.
+* HA configurations for Redis aren't implemented by the provided Kubernetes resource definition files, but Open Match expects the Redis service to be named `redis`, which provides an easier path to multi-instance deployments.
 
 ## Additional examples
 

--- a/config/config.go
+++ b/config/config.go
@@ -43,8 +43,8 @@ var (
 	// REDIS_SENTINEL_PORT_6379_TCP_PROTO=tcp
 	// REDIS_SENTINEL_SERVICE_HOST=10.55.253.195
 	envMappings = map[string]string{
-		"redis.hostname":         "REDIS_SENTINEL_SERVICE_HOST",
-		"redis.port":             "REDIS_SENTINEL_SERVICE_PORT",
+		"redis.hostname":         "REDIS_SERVICE_HOST",
+		"redis.port":             "REDIS_SERVICE_PORT",
 		"redis.pool.maxIdle":     "REDIS_POOL_MAXIDLE",
 		"redis.pool.maxActive":   "REDIS_POOL_MAXACTIVE",
 		"redis.pool.idleTimeout": "REDIS_POOL_IDLETIMEOUT",

--- a/deployments/k8s/redis_service.json
+++ b/deployments/k8s/redis_service.json
@@ -2,7 +2,7 @@
   "kind": "Service",
   "apiVersion": "v1",
   "metadata": {
-    "name": "redis-sentinel"
+    "name": "redis"
   },
   "spec": {
     "selector": {

--- a/docs/development.md
+++ b/docs/development.md
@@ -135,7 +135,7 @@ service/om-mmforc-metrics     ClusterIP   10.59.240.59    <none>        39555/TC
 service/om-mmlogicapi         ClusterIP   10.59.248.3     <none>        50503/TCP        9m
 service/prometheus            NodePort    10.59.252.212   <none>        9090:30900/TCP   9m
 service/prometheus-operated   ClusterIP   None            <none>        9090/TCP         9m
-service/redis-sentinel        ClusterIP   10.59.249.197   <none>        6379/TCP         9m
+service/redis                 ClusterIP   10.59.249.197   <none>        6379/TCP         9m
 
 NAME                                        DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 deployment.extensions/om-backendapi         1         1         1            1           9m

--- a/examples/evaluators/golang/simple/main.go
+++ b/examples/evaluators/golang/simple/main.go
@@ -48,8 +48,8 @@ func main() {
 	// Read config
 	lgr.Println("Initializing config...")
 	cfg, err := readConfig("matchmaker_config", map[string]interface{}{
-		"REDIS_SENTINEL_SERVICE_HOST": "redis-sentinel",
-		"REDIS_SENTINEL_SERVICE_PORT": "6379",
+		"REDIS_SERVICE_HOST": "redis",
+		"REDIS_SERVICE_PORT": "6379",
 		"auth": map[string]string{
 			// Read from k8s secret eventually
 			// Probably doesn't need a map, just here for reference
@@ -63,7 +63,7 @@ func main() {
 	// Connect to redis
 	// As per https://www.iana.org/assignments/uri-schemes/prov/redis
 	// redis://user:secret@localhost:6379/0?foo=bar&qux=baz // redis pool docs: https://godoc.org/github.com/gomodule/redigo/redis#Pool
-	redisURL := "redis://" + cfg.GetString("REDIS_SENTINEL_SERVICE_HOST") + ":" + cfg.GetString("REDIS_SENTINEL_SERVICE_PORT")
+	redisURL := "redis://" + cfg.GetString("REDIS_SERVICE_HOST") + ":" + cfg.GetString("REDIS_SERVICE_PORT")
 	lgr.Println("Connecting to redis at", redisURL)
 	pool := redis.Pool{
 		MaxIdle:     3,
@@ -157,10 +157,10 @@ func readConfig(filename string, defaults map[string]interface{}) (*viper.Viper,
 	   REDIS_SENTINEL_PORT_6379_TCP=tcp://10.55.253.195:6379
 	   REDIS_SENTINEL_PORT=tcp://10.55.253.195:6379
 	   REDIS_SENTINEL_PORT_6379_TCP_ADDR=10.55.253.195
-	   REDIS_SENTINEL_SERVICE_PORT=6379
+	   REDIS_SERVICE_PORT=6379
 	   REDIS_SENTINEL_PORT_6379_TCP_PORT=6379
 	   REDIS_SENTINEL_PORT_6379_TCP_PROTO=tcp
-	   REDIS_SENTINEL_SERVICE_HOST=10.55.253.195
+	   REDIS_SERVICE_HOST=10.55.253.195
 	*/
 	v := viper.New()
 	for key, value := range defaults {

--- a/examples/functions/csharp/simple/Program.cs
+++ b/examples/functions/csharp/simple/Program.cs
@@ -18,8 +18,8 @@ namespace mmfdotnet
     {
         static void Main(string[] args)
         {
-            string host = Environment.GetEnvironmentVariable("REDIS_SENTINEL_SERVICE_HOST");
-            string port = Environment.GetEnvironmentVariable("REDIS_SENTINEL_SERVICE_PORT");
+            string host = Environment.GetEnvironmentVariable("REDIS_SERVICE_HOST");
+            string port = Environment.GetEnvironmentVariable("REDIS_SERVICE_PORT");
 
             // Single connection to the open match redis cluster
             Console.WriteLine($"Connecting to redis...{host}:{port}");

--- a/examples/functions/golang/manual-simple/main.go
+++ b/examples/functions/golang/manual-simple/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	// As per https://www.iana.org/assignments/uri-schemes/prov/redis
 	// redis://user:secret@localhost:6379/0?foo=bar&qux=baz
-	redisURL := "redis://" + os.Getenv("REDIS_SENTINEL_SERVICE_HOST") + ":" + os.Getenv("REDIS_SENTINEL_SERVICE_PORT")
+	redisURL := "redis://" + os.Getenv("REDIS_SERVICE_HOST") + ":" + os.Getenv("REDIS_SERVICE_PORT")
 	fmt.Println("Connecting to Redis at", redisURL)
 	redisConn, err := redis.DialURL(redisURL)
 	if err != nil {

--- a/install/yaml/01-redis-failover.yaml
+++ b/install/yaml/01-redis-failover.yaml
@@ -140,7 +140,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: redis-sentinel
+  name: redis
 spec:
   selector:
     app: openmatch

--- a/install/yaml/01-redis-failover.yaml
+++ b/install/yaml/01-redis-failover.yaml
@@ -1,0 +1,152 @@
+apiVersion: storage.spotahome.com/v1alpha2
+kind: RedisFailover
+metadata:
+  name: redisfailover
+  labels:
+    tier: storage
+spec:
+  hardAntiAffinity: true                     # Optional. Value by default. If true, the pods will not be scheduled on the same node.
+  sentinel:
+    replicas: 3                              # Optional. 3 by default, can be set higher.
+    resources:                               # Optional. If not set, it won't be defined on created resources.
+      requests:
+        cpu: 100m
+      limits:
+        memory: 100Mi
+    customConfig: []                         # Optional. Empty by default.
+  redis:
+    replicas: 3                              # Optional. 3 by default, can be set higher.
+    image: redis                             # Optional. "redis" by default.
+    version: 4.0.11-alpine                   # Optional. "3.2-alpine" by default.
+    resources:                               # Optional. If not set, it won't be defined on created resources
+      requests:
+        cpu: 100m
+        memory: 100Mi
+      limits:
+        cpu: 400m
+        memory: 500Mi
+    exporter: false                          # Optional. False by default. Adds a redis-exporter container to export metrics.
+    exporterImage: oliver006/redis_exporter  # Optional. oliver006/redis_exporter by default.
+    exporterVersion: v0.11.3                 # Optional. v0.11.3 by default.
+    disableExporterProbes: false             # Optional. False by default. Disables the readiness and liveness probes for the exporter.
+    storage:
+      emptyDir: {}                           # Optional. emptyDir by default.
+    customConfig: []                         # Optional. Empty by default.\
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-master-proxy-configmap
+data:
+  haproxy.cfg: |
+    defaults REDIS
+      mode tcp
+      timeout connect 5s
+      timeout client 61s # should respect 'redis.pool.idleTimeout' from open-match config
+      timeout server 61s
+    global
+      stats socket ipv4@127.0.0.1:9999 level admin
+      stats timeout 2m
+    frontend fe_redis
+      bind *:17000 name redis
+      default_backend be_redis
+    backend be_redis
+      server redis-master-serv 127.0.0.1:6379
+
+  redis-master-finder.sh: |
+    #!/bin/sh
+    set -e
+    set -u
+ 
+    SENTINEL_HOST="rfs-redisfailover" # change this if RedisFailover name changes
+
+    LAST_MASTER_IP=""
+    LAST_MASTER_PORT=""
+
+    update_master_addr() {
+        # lookup current master address
+        local r="SENTINEL get-master-addr-by-name mymaster"
+        local r_out=$(echo $r | nc -q1 $SENTINEL_HOST 26379)
+
+        # parse output
+        local master_ip=$(echo "${r_out}" | tail -n+3 | head -n1 | tr -d '\r') # IP is on 3d line
+        local master_port=$(echo "${r_out}" | tail -n+5 | head -n1 | tr -d '\r') # 5th line is port number
+
+        # update HAProxy cfg if needed
+        if [ "$master_ip" != "$LAST_MASTER_IP" ] || [ "$master_port" != "$LAST_MASTER_PORT" ]; then
+            local s="set server be_redis/redis-master-serv addr ${master_ip} port ${master_port}"
+            echo $s | nc 127.0.0.1 9999 # haproxy is in the same pod
+            
+            LAST_MASTER_IP=$master_ip
+            LAST_MASTER_PORT=$master_port
+            echo "New master address is ${LAST_MASTER_IP}:${LAST_MASTER_PORT}"
+        fi
+    }
+
+    while :; do update_master_addr; sleep 1; done
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: redis-master-proxy
+  labels:
+    app: openmatch
+    component: redis
+    tier: storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openmatch
+      component: redis
+      tier: storage
+  template:
+    metadata:
+      labels:
+        app: openmatch
+        component: redis
+        tier: storage
+    spec:
+      volumes:
+      - name: configmap
+        configMap:
+          name: redis-master-proxy-configmap
+          defaultMode: 0700
+      containers:
+      - name: redis-master-haproxy
+        image: haproxy:1.8-alpine
+        ports:
+        - name: haproxy
+          containerPort: 17000
+        - name: haproxy-stats
+          containerPort: 9999
+        volumeMounts:
+        - name: configmap
+          mountPath: /usr/local/etc/haproxy/haproxy.cfg
+          subPath: haproxy.cfg
+      - name: redis-master-finder
+        image: subfuzion/netcat # alpine image with only netcat-openbsd installed
+        imagePullPolicy: Always
+        command: ["redis-master-finder.sh"]
+        volumeMounts:
+        - name: configmap
+          mountPath: /usr/local/bin/redis-master-finder.sh
+          subPath: redis-master-finder.sh
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 100m
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: redis-sentinel
+spec:
+  selector:
+    app: openmatch
+    component: redis
+    tier: storage
+  ports:
+  - protocol: TCP
+    port: 6379
+    targetPort: haproxy

--- a/install/yaml/01-redis.yaml
+++ b/install/yaml/01-redis.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: redis-sentinel
+  name: redis
 spec:
   selector:
     app: mm

--- a/install/yaml/README.md
+++ b/install/yaml/README.md
@@ -34,7 +34,7 @@ service/om-mmforc-metrics     ClusterIP   10.59.240.59    <none>        39555/TC
 service/om-mmlogicapi         ClusterIP   10.59.248.3     <none>        50503/TCP        9m
 service/prometheus            NodePort    10.59.252.212   <none>        9090:30900/TCP   9m
 service/prometheus-operated   ClusterIP   None            <none>        9090/TCP         9m
-service/redis-sentinel        ClusterIP   10.59.249.197   <none>        6379/TCP         9m
+service/redis                 ClusterIP   10.59.249.197   <none>        6379/TCP         9m
 
 NAME                                        DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 deployment.extensions/om-backendapi         1         1         1            1           9m

--- a/test/cmd/client/main.go
+++ b/test/cmd/client/main.go
@@ -31,14 +31,14 @@ import (
 func main() {
 
 	conf, err := readConfig("", map[string]interface{}{
-		"REDIS_SENTINEL_SERVICE_HOST": "127.0.0.1",
-		"REDIS_SENTINEL_SERVICE_PORT": "6379",
+		"REDIS_SERVICE_HOST": "127.0.0.1",
+		"REDIS_SERVICE_PORT": "6379",
 	})
 	check(err, "QUIT")
 
 	// As per https://www.iana.org/assignments/uri-schemes/prov/redis
 	// redis://user:secret@localhost:6379/0?foo=bar&qux=baz
-	redisURL := "redis://" + conf.GetString("REDIS_SENTINEL_SERVICE_HOST") + ":" + conf.GetString("REDIS_SENTINEL_SERVICE_PORT")
+	redisURL := "redis://" + conf.GetString("REDIS_SERVICE_HOST") + ":" + conf.GetString("REDIS_SERVICE_PORT")
 
 	pool := redis.Pool{
 		MaxIdle:     3,


### PR DESCRIPTION
This PR provides an alternative to default "single instance Redis" option:
- Replica set of 3 Redis instances and 3 Sentinels for a failover ([Redis Operator](https://github.com/spotahome/redis-operator) must be installed in cluster)
- Since Redigo doesn't support Sentinel, there's a HAProxy based workaround. Inside the pod, there's a shell script that is monitoring master address (asking Sentinels every second). And if address changes then the script refreshes HAProxy configuration without the restart (writing changes to 'stats socket')