### PR TITLE
added configurable backoff to MatchObject and Player watchers

### DIFF
--- a/config/matchmaker_config.yaml
+++ b/config/matchmaker_config.yaml
@@ -9,11 +9,11 @@ api:
   backend: 
     hostname: om-backendapi
     port: 50505
-    timeout: 30  
+    backoff: "[2 32] *2 ~0.33 <30"
   frontend: 
     hostname: om-frontendapi
     port: 50504
-    timeout: 300
+    backoff: "[2 32] *2 ~0.33 <300"
   mmlogic: 
     hostname: om-mmlogicapi
     port: 50503

--- a/internal/expbo/unmarshal.go
+++ b/internal/expbo/unmarshal.go
@@ -1,0 +1,63 @@
+package expbo
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff"
+)
+
+// UnmarshalExponentialBackOff populates ExponentialBackOff structure parsing strings of format:
+// "[InitInterval MaxInterval] *Multiplier ~RandomizationFactor <MaxElapsedTime"
+//
+// Example: "[0.250 30] *1.5 ~0.33 <7200"
+func UnmarshalExponentialBackOff(s string, b *backoff.ExponentialBackOff) error {
+	var (
+		min, max, mult, rand, limit float64
+		err                         error
+	)
+
+	for _, word := range strings.Split(strings.TrimSpace(s), " ") {
+		switch {
+		case word == "":
+			continue
+		case strings.HasPrefix(word, "["):
+			min, err = strconv.ParseFloat(strings.TrimPrefix(word, "["), 64)
+			if err != nil {
+				return errors.New("cannot parse InitInterval value: " + err.Error())
+			}
+		case strings.HasSuffix(word, "]"):
+			max, err = strconv.ParseFloat(strings.TrimSuffix(word, "]"), 64)
+			if err != nil {
+				return errors.New("cannot parse MaxInterval value: " + err.Error())
+			}
+		case strings.HasPrefix(word, "*"):
+			mult, err = strconv.ParseFloat(strings.TrimPrefix(word, "*"), 64)
+			if err != nil {
+				return errors.New("cannot parse Multiplier value: " + err.Error())
+			}
+		case strings.HasPrefix(word, "~"):
+			rand, err = strconv.ParseFloat(strings.TrimPrefix(word, "~"), 64)
+			if err != nil {
+				return errors.New("cannot parse RandomizationFactor value: " + err.Error())
+			}
+		case strings.HasPrefix(word, "<"):
+			limit, err = strconv.ParseFloat(strings.TrimPrefix(word, "<"), 64)
+			if err != nil {
+				return errors.New("cannot parse MaxElapsedTime value: " + err.Error())
+			}
+		default:
+			return fmt.Errorf(`unexpected word "%s"`, word)
+		}
+	}
+
+	b.InitialInterval = time.Duration(min * float64(time.Second))
+	b.MaxInterval = time.Duration(max * float64(time.Second))
+	b.Multiplier = mult
+	b.RandomizationFactor = rand
+	b.MaxElapsedTime = time.Duration(limit * float64(time.Second))
+	return nil
+}

--- a/internal/expbo/unmarshal_test.go
+++ b/internal/expbo/unmarshal_test.go
@@ -1,0 +1,35 @@
+package expbo
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff"
+)
+
+func TestUnmarshalExponentialBackOff(t *testing.T) {
+	s := "[0.25 30] *1.5 ~0.33 <300"
+
+	b := backoff.NewExponentialBackOff()
+	err := UnmarshalExponentialBackOff(s, b)
+	if err != nil {
+		t.Fatalf(`error umarshaling "%s": %+v`, s, err)
+	}
+
+	if b.InitialInterval != 250*time.Millisecond {
+		t.Error("unexpected InitialInterval value:", b.InitialInterval)
+	}
+	if b.MaxInterval != 30*time.Second {
+		t.Error("unexpected MaxInterval value:", b.MaxInterval)
+	}
+	if math.Abs(b.Multiplier-1.5) > 1e-8 {
+		t.Error("unexpected Multiplier value:", b.Multiplier)
+	}
+	if math.Abs(b.RandomizationFactor-0.33) > 1e-8 {
+		t.Error("unexpected RandomizationFactor value:", b.RandomizationFactor)
+	}
+	if b.MaxElapsedTime != 5*time.Minute {
+		t.Error("unexpected MaxElapsedTime value:", b.MaxElapsedTime)
+	}
+}


### PR DESCRIPTION
Possible solution for #59.
Yes, it's weird to configure backoff this way, but it gives some flexibility, so we may get rid of it once we figure out best suitable values for BO params. 