### PR TITLE
Update git ignore to ignore goland ide files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ msbuild.wrn
 
 # Visual Studio 2015
 .vs/
+
+# Goland
+.idea/


### PR DESCRIPTION
Goland is a free golang ide from jetbrains. This prevents metadata files from accidentally getting checked into source.