### PR TITLE
Add Prometheus service discovery annotations to the Open Match servers.

### DIFF
--- a/install/yaml/02-open-match.yaml
+++ b/install/yaml/02-open-match.yaml
@@ -26,6 +26,10 @@ spec:
       app: openmatch
       component: backend
   template:
+    annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: 9555
+        prometheus.io/path: "/metrics"
     metadata:
       labels:
         app: openmatch
@@ -80,6 +84,10 @@ spec:
       app: openmatch
       component: frontend
   template:
+    annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: 9555
+        prometheus.io/path: "/metrics"
     metadata:
       labels:
         app: openmatch
@@ -134,6 +142,10 @@ spec:
       app: openmatch
       component: mmforc
   template:
+    annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: 9555
+        prometheus.io/path: "/metrics"
     metadata:
       labels:
         app: openmatch
@@ -178,6 +190,10 @@ spec:
       app: openmatch
       component: mmlogic
   template:
+    annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: 9555
+        prometheus.io/path: "/metrics"
     metadata:
       labels:
         app: openmatch


### PR DESCRIPTION
This touches on https://github.com/GoogleCloudPlatform/open-match/issues/46 where we should move towards Prometheus service discovery.