### PR TITLE
Remove symlinks to config files because they are mounted via ConfigMaps.

### DIFF
--- a/cmd/backendapi/matchmaker_config.yaml
+++ b/cmd/backendapi/matchmaker_config.yaml
@@ -1,1 +1,0 @@
-../../config/matchmaker_config.yaml

--- a/cmd/frontendapi/matchmaker_config.yaml
+++ b/cmd/frontendapi/matchmaker_config.yaml
@@ -1,1 +1,0 @@
-../../config/matchmaker_config.yaml

--- a/cmd/mmforc/matchmaker_config.yaml
+++ b/cmd/mmforc/matchmaker_config.yaml
@@ -1,1 +1,0 @@
-../../config/matchmaker_config.yaml

--- a/cmd/mmlogicapi/matchmaker_config.yaml
+++ b/cmd/mmlogicapi/matchmaker_config.yaml
@@ -1,1 +1,0 @@
-../../config/matchmaker_config.yaml

--- a/examples/evaluators/golang/simple/matchmaker_config.yaml
+++ b/examples/evaluators/golang/simple/matchmaker_config.yaml
@@ -1,1 +1,0 @@
-../../../../config/matchmaker_config.yaml

--- a/examples/functions/golang/manual-simple/matchmaker_config.yaml
+++ b/examples/functions/golang/manual-simple/matchmaker_config.yaml
@@ -1,1 +1,0 @@
-../../../../config/matchmaker_config.yaml


### PR DESCRIPTION
There's still a symlink remaining on the helm chart. Not sure how to get rid of that one but suggestions welcome.