### PR TITLE
Fix 'make create-gke-cluster'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ LOCAL_CLOUD_BUILD_PUSH = # --push
 KUBECTL_RUN_ENV = --env='REDIS_SERVICE_HOST=$$(OM_REDIS_MASTER_SERVICE_HOST)' --env='REDIS_SERVICE_PORT=$$(OM_REDIS_MASTER_SERVICE_PORT)'
 GCP_LOCATION_FLAG = --zone $(GCP_ZONE)
 # Flags to simulate behavior of newer versions of Kubernetes
-KUBERNETES_COMPAT = --no-enable-basic-auth -no-issue-client-certificate --enable-ip-alias
+KUBERNETES_COMPAT = --no-enable-basic-auth --no-issue-client-certificate --enable-ip-alias
 GO111MODULE = on
 PROMETHEUS_PORT = 9090
 GRAFANA_PORT = 3000


### PR DESCRIPTION
It is missing a dash on one of the arguments, which breaks things.