### PR TITLE
Disable the PHP example during the CI build.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -88,10 +88,11 @@ steps:
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/openmatch-mmf-go-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}', '-f', 'examples/functions/golang/manual-simple/Dockerfile', '.']
   waitFor: ['Docker Image: open-match-base-build']
 
-- id: 'Docker Image: openmatch-mmf-php-mmlogic-simple'
-  name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/openmatch-mmf-php-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}', '-f', 'examples/functions/php/mmlogic-simple/Dockerfile', '.']
-  waitFor: ['Docker Image: open-match-base-build']
+# Disabled because it's taking up the lionshare of the build.
+#- id: 'Docker Image: openmatch-mmf-php-mmlogic-simple'
+#  name: gcr.io/cloud-builders/docker
+#  args: ['build', '-t', 'gcr.io/$PROJECT_ID/openmatch-mmf-php-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}', '-f', 'examples/functions/php/mmlogic-simple/Dockerfile', '.']
+#  waitFor: ['Docker Image: open-match-base-build']
 
 - id: 'Docker Image: openmatch-mmf-py3-mmlogic-simple'
   name: gcr.io/cloud-builders/docker
@@ -270,7 +271,7 @@ images:
 - 'gcr.io/$PROJECT_ID/openmatch-evaluator-simple:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-mmf-cs-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-mmf-go-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}'
-- 'gcr.io/$PROJECT_ID/openmatch-mmf-php-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}'
+#- 'gcr.io/$PROJECT_ID/openmatch-mmf-php-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-mmf-py3-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-backendclient:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-clientloadgen:${_OM_VERSION}-${SHORT_SHA}'


### PR DESCRIPTION
PHP image build is very expensive because it has to download all the debian build tools like clang to build protobuf and grpc C++ libraries. This alongside all the other build artifacts takes a very long time.