### PR TITLE
Ignore unused directories

### DIFF
--- a/site/app.yaml
+++ b/site/app.yaml
@@ -15,6 +15,13 @@
 runtime: go111
 service: development
 
+skip_files:
+- .*assets
+- .*content
+- .*layouts
+- .*resources
+- .*themes
+
 handlers:
   - url: /site/$
     static_files: public/index.html


### PR DESCRIPTION
When starting the dev_appserver.py to run the Open Match website locally you encounter an error that says: There are too many files in your application for changes in all of them to be monitored.  This change fixes that.