### PR TITLE
Fix build artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,7 +448,8 @@ build/toolchain/bin/protoc$(EXE_EXTENSION):
 	rm $(TOOLCHAIN_DIR)/protoc-temp.zip $(TOOLCHAIN_DIR)/readme.txt
 
 build/toolchain/bin/protoc-gen-go$(EXE_EXTENSION):
-	cd build/toolchain/bin && $(GO) build -pkgdir . github.com/golang/protobuf/protoc-gen-go
+	mkdir -p $(TOOLCHAIN_BIN)
+	cd $(TOOLCHAIN_BIN) && $(GO) build -pkgdir . github.com/golang/protobuf/protoc-gen-go
 
 build/toolchain/bin/protoc-gen-grpc-gateway$(EXE_EXTENSION):
 	mkdir -p $(TOOLCHAIN_DIR)/googleapis-temp/

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ GO = go
 GO_BIN := $(GOPATH)/bin
 GO_SRC := $(GOPATH)/src
 # Defines the absolute local directory of the open-match project
-REPOSITORY_ROOT := $(dir $(abspath $(MAKEFILE_LIST)))
+REPOSITORY_ROOT := $(realpath $(dir $(abspath $(MAKEFILE_LIST))))
 GO_BUILD_COMMAND = CGO_ENABLED=0 GOOS=linux $(GO) build -a -installsuffix cgo .
 BUILD_DIR = $(REPOSITORY_ROOT)/build
 TOOLCHAIN_DIR = $(BUILD_DIR)/toolchain
@@ -448,8 +448,7 @@ build/toolchain/bin/protoc$(EXE_EXTENSION):
 	rm $(TOOLCHAIN_DIR)/protoc-temp.zip $(TOOLCHAIN_DIR)/readme.txt
 
 build/toolchain/bin/protoc-gen-go$(EXE_EXTENSION):
-	$(GO) get github.com/golang/protobuf/protoc-gen-go
-	mv $(GO_BIN)/protoc-gen-go$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-go$(EXE_EXTENSION)
+	cd build/toolchain/bin && $(GO) build -pkgdir . github.com/golang/protobuf/protoc-gen-go
 
 build/toolchain/bin/protoc-gen-grpc-gateway$(EXE_EXTENSION):
 	mkdir -p $(TOOLCHAIN_DIR)/googleapis-temp/
@@ -459,8 +458,7 @@ build/toolchain/bin/protoc-gen-grpc-gateway$(EXE_EXTENSION):
 	cp -rf $(TOOLCHAIN_DIR)/googleapis-temp/googleapis-master/google/api/ \
 		$(PROTOC_INCLUDES)/google/api
 	rm -rf $(TOOLCHAIN_DIR)/googleapis-temp
-	$(GO) get github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
-	mv $(GO_BIN)/protoc-gen-grpc-gateway$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-grpc-gateway$(EXE_EXTENSION)
+	cd build/toolchain/bin && $(GO) build -pkgdir .  github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 
 all-protos: golang-protos mmlogic-simple-protos
 # TODO: Add php-protos to all-protos once it builds the gRPC client code.


### PR DESCRIPTION
This fix issue #180. go build is able to download a temporary source package and build the binaries into -pkgdir directory, which isolates the build environment from users' environment.

Also fixed the REPOSITORY_ROOT variable. This variable used to contains a trailing forward slash e.g. 'src/', which makes BUILD_DIR turns to an invalid path 'src//build'.
