### PR TITLE
Evaluator Harness and Sample golang Evaluator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -91,6 +91,7 @@ cmd/mmforc/mmforc
 cmd/mmlogicapi/mmlogicapi
 examples/backendclient/backendclient
 examples/evaluators/golang/simple/simple
+examples/evaluators/golang/serving/serving
 examples/functions/golang/manual-simple/manual-simple
 examples/functions/golang/grpc-serving/grpc-serving
 test/cmd/clientloadgen/clientloadgen

--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ cmd/mmforc/mmforc
 cmd/mmlogicapi/mmlogicapi
 examples/backendclient/backendclient
 examples/evaluators/golang/simple/simple
+examples/evaluators/golang/serving/serving
 examples/functions/golang/manual-simple/manual-simple
 examples/functions/golang/grpc-serving/grpc-serving
 test/cmd/clientloadgen/clientloadgen

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ push-service-images: push-minimatch-image push-frontendapi-image push-backendapi
 # TODO: push-mmf-php-mmlogic-simple-image
 push-mmf-example-images: push-mmf-cs-mmlogic-simple-image push-mmf-go-mmlogic-simple-image push-mmf-go-grpc-serving-simple-image push-mmf-py3-mmlogic-simple-image
 push-client-images: push-backendclient-image push-clientloadgen-image push-frontendclient-image
-push-evaluator-example-images: push-evaluator-simple-image
+push-evaluator-example-images: push-evaluator-simple-image push-evaluator-serving-image
 
 push-minimatch-image: docker build-minimatch-image
 	docker push $(REGISTRY)/openmatch-minimatch:$(TAG)
@@ -224,12 +224,16 @@ push-evaluator-simple-image: docker build-evaluator-simple-image
 	docker push $(REGISTRY)/openmatch-evaluator-simple:$(TAG)
 	docker push $(REGISTRY)/openmatch-evaluator-simple:$(ALTERNATE_TAG)
 
+push-evaluator-serving-image: build-evaluator-serving-image
+	docker push $(REGISTRY)/openmatch-evaluator-serving:$(TAG)
+	docker push $(REGISTRY)/openmatch-evaluator-serving:$(ALTERNATE_TAG)
+
 build-images: build-service-images build-client-images build-mmf-example-images build-evaluator-example-images
 build-service-images: build-minimatch-image build-frontendapi-image build-backendapi-image build-mmforc-image build-mmlogicapi-image
 build-client-images: build-backendclient-image build-clientloadgen-image build-frontendclient-image
 # TODO build-mmf-php-mmlogic-simple-image
 build-mmf-example-images: build-mmf-cs-mmlogic-simple-image build-mmf-go-mmlogic-simple-image build-mmf-go-grpc-serving-simple-image build-mmf-py3-mmlogic-simple-image
-build-evaluator-example-images: build-evaluator-simple-image
+build-evaluator-example-images: build-evaluator-simple-image build-evaluator-serving-image
 
 build-base-build-image: docker
 	docker build -f Dockerfile.base-build -t open-match-base-build .
@@ -276,6 +280,9 @@ build-frontendclient-image: docker build-base-build-image
 build-evaluator-simple-image: docker build-base-build-image
 	docker build -f examples/evaluators/golang/simple/Dockerfile -t $(REGISTRY)/openmatch-evaluator-simple:$(TAG) -t $(REGISTRY)/openmatch-evaluator-simple:$(ALTERNATE_TAG) .
 
+build-evaluator-serving-image: build-base-build-image
+	docker build -f examples/evaluators/golang/serving/Dockerfile -t $(REGISTRY)/openmatch-evaluator-serving:$(TAG) -t $(REGISTRY)/openmatch-evaluator-serving:$(ALTERNATE_TAG) .
+
 clean-images: docker
 	-docker rmi -f open-match-base-build
 
@@ -294,6 +301,7 @@ clean-images: docker
 	-docker rmi -f $(REGISTRY)/openmatch-clientloadgen:$(TAG) $(REGISTRY)/openmatch-clientloadgen:$(ALTERNATE_TAG)
 	-docker rmi -f $(REGISTRY)/openmatch-frontendclient:$(TAG) $(REGISTRY)/openmatch-frontendclient:$(ALTERNATE_TAG)
 	-docker rmi -f $(REGISTRY)/openmatch-evaluator-simple:$(TAG) $(REGISTRY)/openmatch-evaluator-simple:$(ALTERNATE_TAG)
+	-docker rmi -f $(REGISTRY)/openmatch-evaluator-serving:$(TAG) $(REGISTRY)/openmatch-evaluator-serving:$(ALTERNATE_TAG)
 
 install-redis: build/toolchain/bin/helm$(EXE_EXTENSION)
 	$(HELM) upgrade --install --wait --debug $(REDIS_NAME) stable/redis --namespace $(OPEN_MATCH_KUBERNETES_NAMESPACE)
@@ -634,6 +642,9 @@ examples/backendclient/backendclient: internal/pb/backend.pb.go
 examples/evaluators/golang/simple/simple: internal/pb/messages.pb.go
 	cd examples/evaluators/golang/simple; $(GO_BUILD_COMMAND)
 
+examples/evaluators/golang/serving/serving: internal/pb/messages.pb.go
+	cd examples/evaluators/golang/serving; $(GO_BUILD_COMMAND)
+
 examples/functions/golang/manual-simple/manual-simple: internal/pb/messages.pb.go
 	cd examples/functions/golang/manual-simple; $(GO_BUILD_COMMAND)
 
@@ -695,7 +706,7 @@ service-binaries: cmd/minimatch/minimatch cmd/backendapi/backendapi cmd/frontend
 client-binaries: examples/backendclient/backendclient test/cmd/clientloadgen/clientloadgen test/cmd/frontendclient/frontendclient
 example-binaries: example-mmf-binaries example-evaluator-binaries
 example-mmf-binaries: examples/functions/golang/manual-simple/manual-simple examples/functions/golang/grpc-serving/grpc-serving
-example-evaluator-binaries: examples/evaluators/golang/simple/simple
+example-evaluator-binaries: examples/evaluators/golang/simple/simple examples/evaluators/golang/serving/serving
 
 # For presubmit we want to update the protobuf generated files and verify that tests are good.
 presubmit: sync-deps clean-protos all-protos fmt vet build test
@@ -718,6 +729,7 @@ clean-binaries:
 	rm -rf cmd/mmlogicapi/mmlogicapi
 	rm -rf examples/backendclient/backendclient
 	rm -rf examples/evaluators/golang/simple/simple
+	rm -rf examples/evaluators/golang/serving/serving
 	rm -rf examples/functions/golang/manual-simple/manual-simple
 	rm -rf examples/functions/golang/grpc-serving/grpc-serving
 	rm -rf test/cmd/clientloadgen/clientloadgen

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -168,6 +168,7 @@ artifacts:
             - cmd/mmlogicapi/mmlogicapi
             - examples/functions/golang/manual-simple/manual-simple
             - examples/functions/golang/grpc-serving/grpc-serving
+            - examples/evaluators/golang/serving/serving
             - examples/backendclient/backendclient
             - test/cmd/clientloadgen/clientloadgen
             - test/cmd/frontendclient/frontendclient
@@ -179,6 +180,7 @@ images:
 - 'gcr.io/$PROJECT_ID/openmatch-mmforc:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-mmlogicapi:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-evaluator-simple:${_OM_VERSION}-${SHORT_SHA}'
+- 'gcr.io/$PROJECT_ID/openmatch-evaluator-serving:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-mmf-cs-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-mmf-go-mmlogic-simple:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-mmf-go-grpc-serving-simple:${_OM_VERSION}-${SHORT_SHA}'

--- a/config/matchmaker_config.yaml
+++ b/config/matchmaker_config.yaml
@@ -6,76 +6,77 @@ logging:
   format: text
   source: false
 
-api: 
-  backend: 
+api:
+  backend:
     hostname: om-backendapi
     port: 50505
     backoff: "[2 32] *2 ~0.33 <30"
     proxyport: 51505
-  frontend: 
+  frontend:
     hostname: om-frontendapi
     port: 50504
     backoff: "[2 32] *2 ~0.33 <300"
     proxyport: 51504
-  mmlogic: 
+  mmlogic:
     hostname: om-mmlogicapi
     port: 50503
     proxyport: 51503
   functions:
     port: 50502
     proxyport: 51502
-  
-evalutor:
+
+evaluator:
   # Evaluator intervals are in milliseconds
+  interval: 10
   pollIntervalMs: 1000
   maxWaitMs: 10000
 
-metrics: 
+metrics:
   port: 9555
   endpoint: /metrics
   reportingPeriod: 5
 
-queues: 
-  profiles: 
+queues:
+  profiles:
     name: profileq
     pullCount: 100
-  proposals: 
+  proposals:
     name: proposalq
-  
-ignoreLists: 
-  proposed: 
+
+ignoreLists:
+  proposed:
     name: proposed
     offset: 0
     duration: 800
-  deindexed: 
+  deindexed:
     name: deindexed
     offset: 0
     duration: 800
-  expired: 
+  expired:
     name: OM_METADATA.accessed
     offset: 800
-    duration: 0 
+    duration: 0
 
-defaultImages: 
-  evaluator: 
+defaultImages:
+  evaluator:
     name: gcr.io/open-match-public-images/openmatch-evaluator-simple
     tag: latest
-  mmf: 
+  mmf:
     name: gcr.io/open-match-public-images/openmatch-mmf-py3-mmlogic-simple
     tag: latest
 
-redis: 
-  pool: 
+redis:
+  pool:
     maxIdle: 3
     maxActive: 0
     idleTimeout: 60
   queryArgs:
     count: 10000
-  results: 
+  results:
     pageSize: 10000
-  expirations: 
+  expirations:
     player: 43200
-    matchobject: 43200 
+    matchobject: 43200
 
 jsonkeys:
   mmfImage: imagename

--- a/config/matchmaker_config.yaml
+++ b/config/matchmaker_config.yaml
@@ -25,8 +25,10 @@ api:
     port: 50502
     proxyport: 51502
   
-evalutor: 
-  interval: 10
+evalutor:
+  # Evaluator intervals are in milliseconds
+  pollIntervalMs: 1000
+  maxWaitMs: 10000
 
 metrics: 
   port: 9555

--- a/examples/evaluators/golang/serving/Dockerfile
+++ b/examples/evaluators/golang/serving/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM open-match-base-build as builder
+
+WORKDIR /go/src/github.com/GoogleCloudPlatform/open-match/examples/evaluators/golang/serving/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo .
+
+FROM gcr.io/distroless/static
+COPY --from=builder /go/src/github.com/GoogleCloudPlatform/open-match/examples/evaluators/golang/serving/serving .
+
+ENTRYPOINT ["/serving"]

--- a/examples/evaluators/golang/serving/main.go
+++ b/examples/evaluators/golang/serving/main.go
@@ -1,0 +1,120 @@
+/*
+This is a sample Evaluator built using the Evaluator Harness. It evaluates
+multiple proposals and approves a subset of them. This sample demonstrates 
+how to build a basic Evaluator using the Evaluator Harness . This example 
+over-simplifies the actual evaluation decisions and hence should not be 
+used as is for a real scenario.
+
+Copyright 2018 Google LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	harness "github.com/GoogleCloudPlatform/open-match/internal/harness/evaluator/golang"
+	"github.com/GoogleCloudPlatform/open-match/internal/pb"
+)
+
+func main() {
+	// This invoke the harness to set up the Evaluator. The harness abstracts
+	// fetching proposals ready for evaluation and the process of transforming
+	// approved proposals into results that Open Match can relay to the caller
+	// requesting for matches.
+	harness.RunEvaluator(Evaluate)
+}
+
+func Evaluate(ctx context.Context, proposals []*pb.MatchObject) ([]string, error) {
+
+	// Map of approved and overloaded proposals. Using maps for easier lookup.
+	approvedProposals := make(map[string]bool)
+	overloadedProposals := make(map[string]bool)
+
+	// Map of all the players encountered in the proposals. Each entry maps a player id to
+	// the first match in which the player was encountered.
+	allPlayers := make(map[string]string)
+
+	// Iterate over each proposal to either add to approved map or overloaded map.
+	for _, proposal := range proposals {
+		proposalID := proposal.Id
+		approved := true
+		players := getPlayersInProposal(proposal)
+		// Iterate over each player in the proposal to check if the player was encountered before.
+		for _, pID := range players {
+			if propID, found := allPlayers[pID]; found {
+				// Player was encountered in an earlier proposal. Mark the current proposal as overloaded (not approved).
+				// Also, the first proposal where the player was encountered may have been marked approved. Remove that proposal
+				// approved proposals and add to overloaded proposals since we encountered its player in current proposal too.
+				approved = false
+				delete(approvedProposals, propID)
+				overloadedProposals[propID] = true
+			} else {
+				// Player encountered for the first time, add to all players map with the current proposal.
+				allPlayers[pID] = proposalID
+			}
+
+			if approved {
+				approvedProposals[proposalID] = true
+			} else {
+				overloadedProposals[proposalID] = true
+			}
+		}
+	}
+
+	// Convert the maps to lists of overloaded, approved proposals.
+	overloadedList := []string{}
+	approvedList := []string{}
+	for k := range overloadedProposals {
+		overloadedList = append(overloadedList, k)
+	}
+
+	for k := range approvedProposals {
+		approvedList = append(approvedList, k)
+	}
+
+	// Select proposals to approve from the overloaded proposals list.
+	chosen, err := chooseProposals(overloadedList)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to select approved list from overloaded proposals, %v", err)
+	}
+
+	// Add the chosen proposals to the approved list.
+	approvedList = append(approvedList, chosen...)
+	return approvedList, nil
+}
+
+// chooseProposals should look through all overloaded proposals (that is, have a player that is also
+// in another proposed match) and choose the proposals to approve. This is where the core evaluation
+// logic will be added.
+func chooseProposals(overloaded []string) ([]string, error) {
+	// As a basic example, we pick the first overloaded proposal for approval.
+	approved := []string{}
+	if len(overloaded) > 0 {
+		approved = append(approved, overloaded[0])
+	}
+	return approved, nil
+}
+
+func getPlayersInProposal(proposal *pb.MatchObject) []string {
+	var players []string
+	for _, r := range proposal.Rosters {
+		for _, p := range r.Players {
+			players = append(players, p.Id)
+		}
+	}
+
+	return players
+}

--- a/examples/evaluators/golang/serving/main.go
+++ b/examples/evaluators/golang/serving/main.go
@@ -37,8 +37,13 @@ func main() {
 	harness.RunEvaluator(Evaluate)
 }
 
+// Evaluate is where your custom evaluation logic lives.
+// Input:
+//  - proposals : List of all the proposals to be consiered for evaluation. Each proposal will have 
+//                Rosters comprising of the players belonging to that proposal. 
+// Output:
+//  - (proposals) : List of approved proposal IDs that can be returned as match results.
 func Evaluate(ctx context.Context, proposals []*pb.MatchObject) ([]string, error) {
-
 	// Map of approved and overloaded proposals. Using maps for easier lookup.
 	approvedProposals := make(map[string]bool)
 	overloadedProposals := make(map[string]bool)

--- a/examples/evaluators/golang/serving/main.go
+++ b/examples/evaluators/golang/serving/main.go
@@ -1,8 +1,8 @@
 /*
 This is a sample Evaluator built using the Evaluator Harness. It evaluates
-multiple proposals and approves a subset of them. This sample demonstrates 
-how to build a basic Evaluator using the Evaluator Harness . This example 
-over-simplifies the actual evaluation decisions and hence should not be 
+multiple proposals and approves a subset of them. This sample demonstrates
+how to build a basic Evaluator using the Evaluator Harness . This example
+over-simplifies the actual evaluation decisions and hence should not be
 used as is for a real scenario.
 
 Copyright 2018 Google LLC
@@ -39,18 +39,18 @@ func main() {
 
 // Evaluate is where your custom evaluation logic lives.
 // Input:
-//  - proposals : List of all the proposals to be consiered for evaluation. Each proposal will have 
-//                Rosters comprising of the players belonging to that proposal. 
+//  - proposals : List of all the proposals to be consiered for evaluation. Each proposal will have
+//                Rosters comprising of the players belonging to that proposal.
 // Output:
 //  - (proposals) : List of approved proposal IDs that can be returned as match results.
 func Evaluate(ctx context.Context, proposals []*pb.MatchObject) ([]string, error) {
 	// Map of approved and overloaded proposals. Using maps for easier lookup.
-	approvedProposals := make(map[string]bool)
-	overloadedProposals := make(map[string]bool)
+	approvedProposals := map[string]bool{}
+	overloadedProposals := map[string]bool{}
 
 	// Map of all the players encountered in the proposals. Each entry maps a player id to
 	// the first match in which the player was encountered.
-	allPlayers := make(map[string]string)
+	allPlayers := map[string]string{}
 
 	// Iterate over each proposal to either add to approved map or overloaded map.
 	for _, proposal := range proposals {
@@ -58,8 +58,8 @@ func Evaluate(ctx context.Context, proposals []*pb.MatchObject) ([]string, error
 		approved := true
 		players := getPlayersInProposal(proposal)
 		// Iterate over each player in the proposal to check if the player was encountered before.
-		for _, pID := range players {
-			if propID, found := allPlayers[pID]; found {
+		for _, playerID := range players {
+			if propID, found := allPlayers[playerID]; found {
 				// Player was encountered in an earlier proposal. Mark the current proposal as overloaded (not approved).
 				// Also, the first proposal where the player was encountered may have been marked approved. Remove that proposal
 				// approved proposals and add to overloaded proposals since we encountered its player in current proposal too.
@@ -68,7 +68,7 @@ func Evaluate(ctx context.Context, proposals []*pb.MatchObject) ([]string, error
 				overloadedProposals[propID] = true
 			} else {
 				// Player encountered for the first time, add to all players map with the current proposal.
-				allPlayers[pID] = proposalID
+				allPlayers[playerID] = proposalID
 			}
 
 			if approved {

--- a/internal/harness/evaluator/golang/apisrv/apisrv.go
+++ b/internal/harness/evaluator/golang/apisrv/apisrv.go
@@ -1,0 +1,294 @@
+/*
+
+This server is currently a stand alone application that runs evaluation in a
+conditional loop through its lifetime, calling the user's evaluation method
+in each run. This abstracts the user's evaluation method from how Open Match
+stores proposals, interprets results etc - having the user method to simply
+focus on approving matches from a set of proposals.
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+package apisrv
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/GoogleCloudPlatform/open-match/config"
+	"github.com/GoogleCloudPlatform/open-match/internal/pb"
+	"github.com/GoogleCloudPlatform/open-match/internal/set"
+	redishelpers "github.com/GoogleCloudPlatform/open-match/internal/statestorage/redis"
+	"github.com/GoogleCloudPlatform/open-match/internal/statestorage/redis/ignorelist"
+	"github.com/GoogleCloudPlatform/open-match/internal/statestorage/redis/redispb"
+	"github.com/gomodule/redigo/redis"
+	"go.opencensus.io/tag"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type EvaluateFunction func(context.Context, []*pb.MatchObject) ([]string, error)
+
+// Evaluator contains the configuration for various components of the Evaluator.
+type Evaluator struct {
+	Config   config.View
+	Logger   *log.Entry
+	Pool     *redis.Pool
+	MMLogic  pb.MmLogicClient
+	Evaluate EvaluateFunction
+}
+
+func (s *Evaluator) EvaluateForever() {
+	// Get connection to redis
+	redisConn := s.Pool.Get()
+	defer redisConn.Close()
+
+	start := time.Now()
+	logger := s.Logger
+	checkProposals := true
+	pollInterval := s.Config.GetInt("evaluator.pollIntervalMs")
+	maxWait := s.Config.GetInt64("evaluator.maxWaitMs")
+
+	// This triggers an infinite loop running evaluation on the following conditions:
+	//  - all MMFs are complete OR the evaluation interval is reached
+	//  - AND at least one MMF has been started since the last we evaluated.
+	for {
+		ctx, _ := context.WithCancel(context.Background())
+		cycleStart := time.Now()
+
+		// Get number of running MMFs. 'nil' return from redigo indicates that no new MMFs have even
+		// been started since the last time the evaluator ran.  We don't want to evaluate in that case.
+		r, err := redishelpers.Retrieve(ctx, s.Pool, "concurrentMMFs")
+		if err != nil {
+			if err.Error() == "redigo: nil returned" {
+				// No MMFs have run since we last evaluated; reset timer and loop
+				start = time.Now()
+				time.Sleep(time.Duration(pollInterval) * time.Millisecond)
+			}
+
+			continue
+		}
+
+		numRunning, err := strconv.Atoi(r)
+		if err != nil {
+			logger.Errorf("Failed to retrieve number of currently running MMFs, %v", err)
+		}
+
+		// Some MMFs ran since we last evaluated. We should evaluate the proposal either when all
+		// MMFs are complete, or the timeout is reached.
+		switch {
+		// dividing by 1e6 looks gnarly but is actually the canonical implementation
+		// https://github.com/golang/go/issues/5491
+		case time.Since(start).Nanoseconds()/1e6 >= maxWait:
+			logger.Infof("Maximum evaluator wait time (%v ms) exceeded", maxWait)
+			ctx, _ = tag.New(ctx, tag.Insert(KeyEvalTrigger, "interval_exceeded"))
+			checkProposals = true
+
+		case numRunning <= 0: // Can be less than zero in some less common cases.
+			logger.Info("All MMFs complete, trigger evaluation")
+			ctx, _ = tag.New(ctx, tag.Insert(KeyEvalTrigger, "mmfs_completed"))
+			numRunning = 0
+			checkProposals = true
+		}
+
+		if checkProposals {
+			// Only run the evaluator if there are queued proposals.
+			checkProposals = false
+			results, err := redishelpers.Count(context.Background(), s.Pool, s.Config.GetString("queues.proposals.name"))
+			switch {
+			case err != nil:
+				logger.Errorf("Failed to retrieve the length of the proposal queue from statestorage, %v", err)
+			case results == 0:
+				logger.Info("no proposals in the queue to evaluate")
+			default:
+				logger.Infof("%v proposals available, evaluating", results)
+				go s.evaluator(ctx)
+			}
+
+			// Delete the counter.  This causes subsequent queries to return 'nil' until it is
+			// re-created again on first write.  This enables us to skip evaluation logic if no MMF
+			// has written to the counter since last evaluation.
+			err = redishelpers.Delete(context.Background(), s.Pool, "concurrentMMFs")
+			if err != nil {
+				logger.WithFields(log.Fields{
+					"error": err.Error(),
+				}).Error("error deleting concurrent MMF counter")
+			}
+			start = time.Now()
+		}
+
+		// A sleep here is not critical but just a useful safety valve in case
+		// things are broken, to keep the main loop from going all-out and spamming the log.
+		logger.WithFields(log.Fields{"elapsed": time.Since(cycleStart)}).Info("Evaluation complete. Sleeping for 1 sec.")
+		time.Sleep(time.Duration(1000) * time.Millisecond)
+	}
+}
+
+// evaluator queries all the proposals from Open Match and calls the user's evaluator with this collection
+// of proposals. It receives approved proposals which it then updates in Open Match as results.
+func (s *Evaluator) evaluator(ctx context.Context) error {
+	logger := s.Logger
+	logger.Info("Starting evaluation")
+
+	// Get connection to redis
+	redisConn := s.Pool.Get()
+	defer redisConn.Close()
+
+	start := time.Now()
+	// Get the number of proposals currently queued for evaluation.
+	proposalq := s.Config.GetString("queues.proposals.name")
+	numProposals, err := redis.Int(redisConn.Do("SCARD", proposalq))
+	if err != nil {
+		logger.Errorf("Failed to get proposal count from %v queue, %v", proposalq, err)
+		return err
+	}
+
+	// Get the proposal IDs for the currently queued proposals.
+	proposalIds, err := redis.Strings(redisConn.Do("SPOP", proposalq, numProposals))
+	if err != nil {
+		logger.Errorf("Failed to pop %v proposal ids from %v queue, %v", numProposals, proposalq, err)
+		return err
+	}
+
+	logger.Infof("Retrieved %v proposal ids from %v queue", numProposals, proposalq)
+
+	// Fetch all the proposals from Open Match state storage.
+	proposals, err := s.getProposals(proposalIds)
+	if err != nil {
+		logger.Errorf("Failed to fetch proposals from redis, %v", err)
+		return err
+	}
+
+	// Call the user's evaluation callback to get a list of approved proposals.
+	approvedProposals, err := s.Evaluate(ctx, proposals)
+	logger.Infof("List of approved proposals: %v", approvedProposals)
+
+	// Create a map of proposals to access a proposal by its ID.
+	proposalMap := make(map[string]*pb.MatchObject)
+	for _, p := range proposals {
+		proposalMap[p.Id] = p
+	}
+
+	// Arrays used to look for rejected players
+	approvedPlayers := []string{}
+	potentiallyRejectedPlayers := []string{}
+
+	// Run redis commands to approve matches
+	for _, proposalID := range approvedProposals {
+		// The proposal is marked as a result by updating its name to the result name expected by the backend API.
+		// Sample proposal id: proposal.80e43fa085844eebbf53fc736150ef96.testprofile
+		// format: "proposal".unique_matchobject_id.profile_name
+		// Expected result id format: unique_matchobject_id.profile_name
+		values := strings.Split(proposalID, ".")
+		moID, proID := values[1], values[2]
+		resultID := moID + "." + proID
+
+		a := getPlayersInProposal(proposalMap[proposalID])
+		approvedPlayers = append(approvedPlayers, a...)
+
+		// Approve the match
+		logger.Infof("approving proposalID: %v -> %v", proposalID, resultID)
+		_, err = redisConn.Do("RENAME", proposalID, resultID)
+		if err != nil {
+			// RENAME only fails if the source key doesn't exist
+			logger.Error("Failure to move proposal to approved resultID! ", err)
+		}
+	}
+
+	rejectedProposals := set.Difference(proposalIds, approvedProposals)
+	for _, proposalID := range rejectedProposals {
+		values := strings.Split(proposalID, ".")
+		moID, proID := values[1], values[2]
+		resultID := moID + "." + proID
+
+		pr := getPlayersInProposal(proposalMap[proposalID])
+		potentiallyRejectedPlayers = append(potentiallyRejectedPlayers, pr...)
+		logger.Infof("approving proposalID: %v -> %v", proposalID, resultID)
+
+		// Set error message
+		_, err = redisConn.Do("HSET", proposalID, "error", "Proposed match rejected due to player conflict")
+		if err != nil {
+			logger.Errorf("Failure to set rejected error for proposal %v", err, proposalID)
+		}
+
+		// Remove any rosters
+		_, err = redisConn.Do("HSET", proposalID, "rosters", "")
+		if err != nil {
+			logger.Errorf("Failure to delete rejected rosters for proposal %v", err, proposalID)
+		}
+
+		_, err = redisConn.Do("RENAME", proposalID, resultID)
+		if err != nil {
+			logger.Errorf("Failure to delete rejected proposal for proposal %v", err, proposalID)
+		}
+	}
+
+	// Remove players that are (only) in the rejected games from the ignorelist
+	rejectedPlayers := set.Difference(potentiallyRejectedPlayers, approvedPlayers)
+	logger.Infof("Approved Players: %v", approvedPlayers)
+	logger.Infof("Rejected Players: %v", rejectedPlayers)
+
+	if len(rejectedPlayers) > 0 {
+		logger.Info("Removing rejectedPlayers from 'proposed' ignorelist")
+		err = ignorelist.Remove(redisConn, "proposed", rejectedPlayers)
+		if err != nil {
+			logger.Error("Failed to remove rejected players from ignorelist", err)
+		}
+	} else {
+		logger.Infof("No rejected players to re-queue!")
+	}
+
+	logger.Infof("Finished evaluation in %v seconds.", time.Since(start).Seconds())
+	return nil
+}
+
+func (s *Evaluator) getProposals(ids []string) ([]*pb.MatchObject, error) {
+	var proposals []*pb.MatchObject
+	for _, proposalID := range ids {
+		proposal, err := s.getProposal(proposalID)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get proposal for id %v, %v", proposalID, err)
+		}
+
+		proposals = append(proposals, proposal)
+	}
+
+	return proposals, nil
+}
+
+func (s *Evaluator) getProposal(proposalID string) (*pb.MatchObject, error) {
+	proposal := &pb.MatchObject{Id: proposalID}
+	err := redispb.UnmarshalFromRedis(context.Background(), s.Pool, proposal)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to fetch proposal id %v from redis, %v", proposalID, err)
+	}
+
+	return proposal, nil
+}
+
+func getPlayersInProposal(proposal *pb.MatchObject) []string {
+	var players []string
+	for _, r := range proposal.Rosters {
+		for _, p := range r.Players {
+			players = append(players, p.Id)
+		}
+	}
+
+	return players
+}

--- a/internal/harness/evaluator/golang/apisrv/evaluator_stats.go
+++ b/internal/harness/evaluator/golang/apisrv/evaluator_stats.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package apisrv
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// OpenCensus Measures. These are exported as metrics to your monitoring system
+// https://godoc.org/go.opencensus.io/stats
+//
+// When making opencensus stats, the 'name' param, with forward slashes changed
+// to underscores, is appended to the 'namespace' value passed to the
+// prometheus exporter to become the Prometheus metric name. You can also look
+// into having Prometheus rewrite your metric names on scrape.
+//
+//  For example:
+//   - defining the promethus export namespace "open_match" when instanciating the exporter:
+//			pe, err := promethus.NewExporter(promethus.Options{Namespace: "open_match"})
+//   - and naming the request counter "backend/requests_total":
+//			MGrpcRequests := stats.Int64("backendapi/requests_total", ...
+//   - results in the prometheus metric name:
+//			open_match_backendapi_requests_total
+//   - [note] when using opencensus views to aggregate the metrics into
+//     distribution buckets and such, multiple metrics
+//     will be generated with appended types ("<metric>_bucket",
+//     "<metric>_count", "<metric>_sum", for example)
+//
+// In addition, OpenCensus stats propogated to Prometheus have the following
+// auto-populated labels pulled from kubernetes, which we should avoid to
+// prevent overloading and having to use the HonorLabels param in Prometheus.
+//
+// - Information about the k8s pod being monitored:
+//		"pod" (name of the monitored k8s pod)
+//		"namespace" (k8s namespace of the monitored pod)
+// - Information about how promethus is gathering the metrics:
+//		"instance" (IP and port number being scraped by prometheus)
+//		"job" (name of the k8s service being scraped by prometheus)
+//		"endpoint" (name of the k8s port in the k8s service being scraped by prometheus)
+//
+var (
+	// Logging instrumentation
+	// There's no need to record this measurement directly if you use
+	// the logrus hook provided in metrics/helper.go after instantiating the
+	// logrus instance in your application code.
+	// https://godoc.org/github.com/sirupsen/logrus#LevelHooks
+	EvaluatorLogLines = stats.Int64("evaluator/logs_total", "Number of evaluator lines logged", "1")
+
+	// Instrumentation for evaluator execution.
+	Evaluations        = stats.Int64("evaluator/evaluations_total", "Number of times all existing proposals have been evaluated", "1")
+	EvaluationFailures = stats.Int64("evaluator/failures_total", "Number of failures attempting to evaluate all existing proposals", "1")
+)
+
+var (
+	// KeyEvalTrigger is used to tag which code path caused the evaluator to run.
+	KeyEvalTrigger, _ = tag.NewKey("evalTrigger")
+	// KeySeverity is used to tag a the severity of a log message.
+	KeySeverity, _ = tag.NewKey("severity")
+)
+
+var (
+	// Latency in buckets:
+	// [>=0ms, >=25ms, >=50ms, >=75ms, >=100ms, >=200ms, >=400ms, >=600ms, >=800ms, >=1s, >=2s, >=4s, >=6s]
+	latencyDistribution = view.Distribution(0, 25, 50, 75, 100, 200, 400, 600, 800, 1000, 2000, 4000, 6000)
+)
+
+// Package metrics provides some convience views.
+// You need to register the views for the data to actually be collected.
+// Note: The OpenCensus View 'Description' is exported to Prometheus as the HELP string.
+// Note: If you get a "Failed to export to Prometheus: inconsistent label
+// cardinality" error, chances are you forgot to set the tags specified in the
+// view for a given measure when you tried to do a stats.Record()
+var (
+	EvaluatorCountView = &view.View{
+		Name:        "evaluator/evaluations_total",
+		Measure:     Evaluations,
+		Description: "Number of times all existing proposals have been evaluated",
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{KeyEvalTrigger},
+	}
+
+	EvaluatorFailuresCountView = &view.View{
+		Name:        "evaluator/failures_total",
+		Measure:     EvaluationFailures,
+		Description: "Number of failures attempting to evaluate all existing proposals",
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{KeyEvalTrigger},
+	}
+)
+
+// DefaultEvaluatorViews are the default matchmaker orchestrator OpenCensus measure views.
+var DefaultEvaluatorViews = []*view.View{
+	EvaluatorCountView,
+	EvaluatorFailuresCountView,
+}

--- a/internal/harness/evaluator/golang/doc.go
+++ b/internal/harness/evaluator/golang/doc.go
@@ -1,0 +1,16 @@
+/*
+Evaluator harness contains common scaffolding needed by the Evaluator. The
+harness currently runs the evaluator loop that periodically scans the database
+for new proposals and calls the user defined evaluation function with the
+collection of proposals. The harness accepts the approved matches from the user
+and modifies the database to indicate these results.
+
+Currently, the harness logic simply abstracts the user from the database
+concepts. In future, as the proposals move out of the database, this harness
+will be a GRPC service that accepts proposal stream from Open Match and
+calls user's evaluation logic with this collection of proposals. Thus the
+harness will minimize impact of these future changes on user's evaluation
+function.
+*/
+
+package harness

--- a/internal/harness/evaluator/golang/harness.go
+++ b/internal/harness/evaluator/golang/harness.go
@@ -1,0 +1,145 @@
+/*
+This application handles the scaffolding for the Evaluator. Currently this is
+simply does some initializations for the components needed by the Evaluator.
+In future, this application will initialize a GRPC server harness that Open
+Match will call to synchronize evaluation.
+
+Note that this method only has the initialization code for the evaluator. All
+the actual important bits are in the API Server source code: apisrv/apisrv.go
+
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package harness
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/GoogleCloudPlatform/open-match/config"
+	"github.com/GoogleCloudPlatform/open-match/internal/harness/evaluator/golang/apisrv"
+	"github.com/GoogleCloudPlatform/open-match/internal/logging"
+	"github.com/GoogleCloudPlatform/open-match/internal/metrics"
+	"github.com/GoogleCloudPlatform/open-match/internal/pb"
+	redishelpers "github.com/GoogleCloudPlatform/open-match/internal/statestorage/redis"
+	"github.com/GoogleCloudPlatform/open-match/internal/util/netlistener"
+	"go.opencensus.io/stats/view"
+	"google.golang.org/grpc"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// RunEvaluator is a hook for the main() method in the evaluator executable.
+func RunEvaluator(fn apisrv.EvaluateFunction) {
+	evaluator, err := newEvaluator(fn)
+	if err != nil {
+		log.Errorf("Cannot construct the Evaluator, %v", err)
+		return
+	}
+
+	evaluator.EvaluateForever()
+}
+
+// newEvaluator creates and initializes an Evaluator.
+func newEvaluator(fn apisrv.EvaluateFunction) (*apisrv.Evaluator, error) {
+	log.AddHook(metrics.NewHook(apisrv.EvaluatorLogLines, apisrv.KeySeverity))
+	logger := log.WithFields(log.Fields{
+		"app":       "openmatch",
+		"component": "evaluator"})
+	log.SetReportCaller(true)
+
+	// Initialize the configuration
+	cfg, err := config.Read()
+	if err != nil {
+		logger.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Error("Unable to load config file")
+		return nil, err
+	}
+
+	// Configure Open Match logging defaults
+	logging.ConfigureLogging(cfg)
+
+	// Configure OpenCensus exporter to Prometheus
+	// metrics.ConfigureOpenCensusPrometheusExporter expects that every OpenCensus view you
+	// want to register is in an array, so append any views you want from other
+	// packages to a single array here.
+	ocEvaluatorViews := []*view.View{}
+	ocEvaluatorViews = append(ocEvaluatorViews, apisrv.DefaultEvaluatorViews...)
+	ocEvaluatorViews = append(ocEvaluatorViews, config.CfgVarCountView) // config loader view.
+
+	logger.WithFields(log.Fields{"viewscount": len(ocEvaluatorViews)}).Info("Loaded OpenCensus views")
+
+	promLh, err := netlistener.NewFromPortNumber(cfg.GetInt("metrics.port"))
+	if err != nil {
+		logger.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Error("Unable to create metrics TCP listener")
+		return nil, err
+	}
+	metrics.ConfigureOpenCensusPrometheusExporter(promLh, cfg, ocEvaluatorViews)
+
+	// Get the MMLogic client.
+	mmlogic, err := getMMLogicClient(cfg)
+	if err != nil {
+		logger.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Error("Failed to get MMLogic client")
+		return nil, err
+	}
+
+	// Get redis connection pool.
+	pool, err := redishelpers.ConnectionPool(cfg)
+	if err != nil {
+		logger.WithFields(log.Fields{
+			"error": err.Error(),
+		}).Error("Unable to connect to redis")
+		return nil, err
+	}
+
+	evaluator := &apisrv.Evaluator{
+		Logger:   logger,
+		Config:   cfg,
+		Pool:     pool,
+		MMLogic:  mmlogic,
+		Evaluate: fn,
+	}
+
+	return evaluator, nil
+}
+
+func getMMLogicClient(cfg config.View) (pb.MmLogicClient, error) {
+	host := cfg.GetString("api.mmlogic.hostname")
+	if len(host) == 0 {
+		return nil, fmt.Errorf("Failed to get hostname for MMLogicAPI from the environment")
+	}
+
+	port := cfg.GetString("api.mmlogic.port")
+	if len(port) == 0 {
+		return nil, fmt.Errorf("Failed to get port for MMLogicAPI from the environment")
+	}
+
+	ip, err := net.LookupHost(host)
+	if err != nil || len(ip) == 0 {
+		return nil, fmt.Errorf("Failed to get IP for MMLogicAPI, %v", err)
+	}
+
+	conn, err := grpc.Dial(fmt.Sprintf("%v:%v", ip, port), grpc.WithInsecure())
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %v, %v", fmt.Sprintf("%v:%v", ip, port), err)
+	}
+
+	return pb.NewMmLogicClient(conn), nil
+}

--- a/internal/harness/evaluator/golang/harness.go
+++ b/internal/harness/evaluator/golang/harness.go
@@ -26,7 +26,6 @@ package harness
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/GoogleCloudPlatform/open-match/config"
 	"github.com/GoogleCloudPlatform/open-match/internal/harness/evaluator/golang/apisrv"
@@ -123,22 +122,17 @@ func newEvaluator(fn apisrv.EvaluateFunction) (*apisrv.Evaluator, error) {
 func getMMLogicClient(cfg config.View) (pb.MmLogicClient, error) {
 	host := cfg.GetString("api.mmlogic.hostname")
 	if len(host) == 0 {
-		return nil, fmt.Errorf("Failed to get hostname for MMLogicAPI from the environment")
+		return nil, fmt.Errorf("Failed to get hostname for MMLogicAPI from the configuration")
 	}
 
 	port := cfg.GetString("api.mmlogic.port")
 	if len(port) == 0 {
-		return nil, fmt.Errorf("Failed to get port for MMLogicAPI from the environment")
+		return nil, fmt.Errorf("Failed to get port for MMLogicAPI from the configuration")
 	}
 
-	ip, err := net.LookupHost(host)
-	if err != nil || len(ip) == 0 {
-		return nil, fmt.Errorf("Failed to get IP for MMLogicAPI, %v", err)
-	}
-
-	conn, err := grpc.Dial(fmt.Sprintf("%v:%v", ip, port), grpc.WithInsecure())
+	conn, err := grpc.Dial(fmt.Sprintf("%v:%v", host, port), grpc.WithInsecure())
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to %v, %v", fmt.Sprintf("%v:%v", ip, port), err)
+		return nil, fmt.Errorf("failed to connect to %v, %v", fmt.Sprintf("%v:%v", host, port), err)
 	}
 
 	return pb.NewMmLogicClient(conn), nil


### PR DESCRIPTION
This PR implements a generic Evaluator harness that abstracts all the Open Match specific data concepts (Redis reads etc.) away from the user's evaluation function. In future releases, these will change completely and the user logic should still be minimally impacted. 

The PR also implements a sample barebones evaluator example that simply de-collides proposals.