### PR TITLE
Self-Certificate generation for Open Match. (#273)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ examples/evaluators/golang/serving/serving
 examples/functions/golang/grpc-serving/grpc-serving
 test/cmd/clientloadgen/clientloadgen
 test/cmd/frontendclient/frontendclient
+tools/certgen/certgen

--- a/Makefile
+++ b/Makefile
@@ -375,10 +375,11 @@ set-redis-password:
 		printf "apiVersion: v1\nkind: Secret\nmetadata:\n  name: $(REDIS_NAME)\n  namespace: $(OPEN_MATCH_KUBERNETES_NAMESPACE)\ndata:\n  redis-password: $$REDIS_PASSWORD\n" | \
 		$(KUBECTL) replace -f - --force
 
-install-toolchain: install-kubernetes-tools install-web-tools install-protoc-tools
+install-toolchain: install-kubernetes-tools install-web-tools install-protoc-tools install-openmatch-tools
 install-kubernetes-tools: build/toolchain/bin/kubectl$(EXE_EXTENSION) build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/minikube$(EXE_EXTENSION) build/toolchain/bin/skaffold$(EXE_EXTENSION)
 install-web-tools: build/toolchain/bin/hugo$(EXE_EXTENSION) build/toolchain/bin/htmltest$(EXE_EXTENSION) build/toolchain/nodejs/
 install-protoc-tools: build/toolchain/bin/protoc$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-go$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-grpc-gateway$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-swagger$(EXE_EXTENSION)
+install-openmatch-tools: build/toolchain/bin/certgen$(EXE_EXTENSION)
 
 build/toolchain/bin/helm$(EXE_EXTENSION):
 	mkdir -p $(TOOLCHAIN_BIN)
@@ -477,6 +478,10 @@ ifeq ($(suffix $(NODEJS_PACKAGE_NAME)),.zip)
 else
 	cd build/toolchain/nodejs/ && tar xzf ../../archives/$(NODEJS_PACKAGE_NAME) --strip-components 1
 endif
+
+build/toolchain/bin/certgen$(EXE_EXTENSION): tools/certgen/certgen$(EXE_EXTENSION)
+	mkdir -p $(TOOLCHAIN_BIN)
+	cp -f $(REPOSITORY_ROOT)/tools/certgen/certgen$(EXE_EXTENSION) $(TOOLCHAIN_BIN)/certgen$(EXE_EXTENSION)
 
 push-helm: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/kubectl$(EXE_EXTENSION)
 	$(KUBECTL) create serviceaccount --namespace kube-system tiller
@@ -603,6 +608,13 @@ test/cmd/clientloadgen/clientloadgen$(EXE_EXTENSION):
 test/cmd/frontendclient/frontendclient$(EXE_EXTENSION): internal/pb/frontend.pb.go internal/pb/messages.pb.go
 	cd test/cmd/frontendclient; $(GO_BUILD_COMMAND)
 
+tools/certgen/certgen$(EXE_EXTENSION):
+	cd tools/certgen/ && $(GO_BUILD_COMMAND)
+
+build/certificates/: build/toolchain/bin/certgen$(EXE_EXTENSION)
+	mkdir -p $(BUILD_DIR)/certificates/
+	cd $(BUILD_DIR)/certificates/ && $(REPOSITORY_ROOT)/build/toolchain/bin/certgen$(EXE_EXTENSION)
+
 node_modules/: build/toolchain/nodejs/
 	-rm -r package.json package-lock.json
 	-rm -rf node_modules/
@@ -656,12 +668,13 @@ else
 	echo "Not deploying development.open-match.dev because this is not a post commit change."
 endif
 
-all: service-binaries client-binaries example-binaries
+all: service-binaries client-binaries example-binaries tools-binaries
 service-binaries: cmd/minimatch/minimatch$(EXE_EXTENSION) cmd/backendapi/backendapi$(EXE_EXTENSION) cmd/frontendapi/frontendapi$(EXE_EXTENSION) cmd/mmlogicapi/mmlogicapi$(EXE_EXTENSION)
 client-binaries: examples/backendclient/backendclient$(EXE_EXTENSION) test/cmd/clientloadgen/clientloadgen$(EXE_EXTENSION) test/cmd/frontendclient/frontendclient$(EXE_EXTENSION)
 example-binaries: example-mmf-binaries example-evaluator-binaries
 example-mmf-binaries: examples/functions/golang/grpc-serving/grpc-serving$(EXE_EXTENSION)
 example-evaluator-binaries: examples/evaluators/golang/serving/serving$(EXE_EXTENSION)
+tools-binaries: tools/certgen/certgen$(EXE_EXTENSION)
 
 # For presubmit we want to update the protobuf generated files and verify that tests are good.
 presubmit: update-deps clean-protos all-protos fmt vet build test

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/viper v1.3.2
-	github.com/stretchr/testify v1.3.0 // indirect
+	github.com/stretchr/testify v1.3.0
 	github.com/tidwall/gjson v1.2.1
 	github.com/tidwall/match v1.0.1 // indirect
 	github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 // indirect

--- a/tools/certgen/certgen.go
+++ b/tools/certgen/certgen.go
@@ -1,0 +1,36 @@
+package main
+
+// This code is an adapted version of https://golang.org/src/crypto/tls/generate_cert.go
+
+import (
+	"flag"
+	"log"
+	"time"
+
+	certgenInternal "github.com/GoogleCloudPlatform/open-match/tools/certgen/internal"
+)
+
+var (
+	publicKeyFlag        = flag.String("publickey", "public.cert", "Public key certificate path")
+	privateKeyFlag       = flag.String("privatekey", "private.key", "Private key PEM file path")
+	validityDurationFlag = flag.Duration("duration", time.Hour*24*365*5, "Lifetime for certificate validity (default is 5 years)")
+	hostnamesFlag        = flag.String("hostnames", "om-frontendapi,om-backendapi,om-mmforc,om-function,om-mmlogicapi,om-evaluator", "Comma separated list of host names.")
+	rsaKeyLengthFlag     = flag.Int("rsa", 2048, "RSA Encryption Key bit length for certificate.")
+)
+
+func main() {
+	flag.Parse()
+	if err := createCertificateViaFlags(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func createCertificateViaFlags() error {
+	return certgenInternal.CreateCertificateAndPrivateKeyFiles(&certgenInternal.Params{
+		PublicKeyPath:    *publicKeyFlag,
+		PrivateKeyPath:   *privateKeyFlag,
+		ValidityDuration: *validityDurationFlag,
+		Hostnames:        *hostnamesFlag,
+		RSAKeyLength:     *rsaKeyLengthFlag,
+	})
+}

--- a/tools/certgen/internal/internal.go
+++ b/tools/certgen/internal/internal.go
@@ -1,0 +1,124 @@
+package internal
+
+// This code is an adapted version of https://golang.org/src/crypto/tls/generate_cert.go
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	country          = "US"
+	organization     = "Open Match"
+	organizationUnit = "OM"
+	locality         = "Mountain View"
+	province         = "CA"
+)
+
+// Params for creating an X.509 certificate and RSA private key pair for TLS.
+type Params struct {
+	PublicKeyPath    string
+	PrivateKeyPath   string
+	ValidityDuration time.Duration
+	Hostnames        string
+	RSAKeyLength     int
+}
+
+// GetHostnames returns all the hosts this certificate can handle.
+func (p *Params) GetHostnames() []string {
+	return strings.Split(p.Hostnames, ",")
+}
+
+// CreateCertificateAndPrivateKeyFiles writes the random public certificate and private key pair to disk.
+func CreateCertificateAndPrivateKeyFiles(params *Params) error {
+	publicKeyPemBytes, privateKeyPemBytes, err := CreateCertificateAndPrivateKey(params)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(params.PublicKeyPath, publicKeyPemBytes, 0644); err != nil {
+		return errors.WithStack(err)
+	}
+	if err = ioutil.WriteFile(params.PrivateKeyPath, privateKeyPemBytes, 0644); err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}
+
+// CreateCertificateAndPrivateKey returns the public certificate and private key pair as byte arrays.
+func CreateCertificateAndPrivateKey(params *Params) ([]byte, []byte, error) {
+	startTimestamp := time.Now()
+	expirationTimestamp := startTimestamp.Add(params.ValidityDuration)
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return []byte{}, []byte{}, errors.WithStack(err)
+	}
+	pkixName := pkix.Name{
+		Country:            []string{country},
+		Organization:       []string{organization},
+		OrganizationalUnit: []string{organizationUnit},
+		Locality:           []string{locality},
+		Province:           []string{province},
+		CommonName:         organization,
+		SerialNumber:       serialNumber.String(),
+	}
+	certTemplate := x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkixName,
+		Issuer:                pkixName,
+		NotBefore:             startTimestamp,
+		NotAfter:              expirationTimestamp,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	for _, hostname := range params.GetHostnames() {
+		if ipAddress := net.ParseIP(hostname); ipAddress != nil {
+			certTemplate.IPAddresses = append(certTemplate.IPAddresses, ipAddress)
+		} else {
+			certTemplate.DNSNames = append(certTemplate.DNSNames, hostname)
+		}
+	}
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, params.RSAKeyLength)
+	if err != nil {
+		return []byte{}, []byte{}, errors.WithStack(err)
+	}
+
+	cert, err := x509.CreateCertificate(rand.Reader, &certTemplate, &certTemplate, publicKey(privateKey), privateKey)
+	if err != nil {
+		return []byte{}, []byte{}, errors.WithStack(err)
+	}
+
+	publicKeyPemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert,
+	})
+	pemPrivateKey := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+	privateKeyPemBytes := pem.EncodeToMemory(pemPrivateKey)
+
+	return publicKeyPemBytes, privateKeyPemBytes, nil
+}
+
+func publicKey(priv interface{}) interface{} {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	default:
+		return nil
+	}
+}

--- a/tools/certgen/internal/internal_test.go
+++ b/tools/certgen/internal/internal_test.go
@@ -1,0 +1,79 @@
+package internal
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	secretMessage = "this is a secret message"
+)
+
+func TestParamsGetHostname(t *testing.T) {
+	assert := assert.New(t)
+	p := &Params{
+		Hostnames: "a.com,b.com,127.0.0.1",
+	}
+	assert.ElementsMatch([]string{"a.com", "b.com", "127.0.0.1"}, p.GetHostnames())
+}
+
+func TestCreateCertificate(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpDir, err := ioutil.TempDir("", "certtest")
+	defer func() {
+		assert.Nil(os.RemoveAll(tmpDir))
+	}()
+	assert.Nil(err)
+	publicCertPath := filepath.Join(tmpDir, "public.cert")
+	privateKeyPath := filepath.Join(tmpDir, "private.key")
+	err = CreateCertificateAndPrivateKeyFiles(&Params{
+		PublicKeyPath:    publicCertPath,
+		PrivateKeyPath:   privateKeyPath,
+		ValidityDuration: time.Hour * 1,
+		Hostnames:        "a.com,b.com,127.0.0.1",
+		RSAKeyLength:     2048,
+	})
+	assert.Nil(err)
+
+	assert.FileExists(publicCertPath)
+	assert.FileExists(privateKeyPath)
+
+	publicCertFileData, err := ioutil.ReadFile(publicCertPath)
+	assert.Nil(err)
+	privateKeyFileData, err := ioutil.ReadFile(privateKeyPath)
+	assert.Nil(err)
+
+	// Verify that we can load the public/private key pair.
+	publicCertPemBlock, remainder := pem.Decode(publicCertFileData)
+	assert.Empty(remainder)
+	pub, err := x509.ParseCertificate(publicCertPemBlock.Bytes)
+	assert.Nil(err)
+	assert.NotNil(pub)
+	privateKeyPemBlock, remainder := pem.Decode(privateKeyFileData)
+	assert.Empty(remainder)
+	pk, err := x509.ParsePKCS1PrivateKey(privateKeyPemBlock.Bytes)
+	assert.Nil(err)
+	assert.NotNil(publicCertFileData)
+	assert.NotNil(pk)
+
+	// Verify that the public/private key pair can RSA encrypt/decrypt.
+	pubKey, ok := pub.PublicKey.(*rsa.PublicKey)
+	assert.True(ok, "pub.PublicKey is not of type, *rsa.PublicKey, %v", pub.PublicKey)
+	ciphertext, err := rsa.EncryptOAEP(sha256.New(), rand.Reader, pubKey, []byte(secretMessage), []byte{})
+	assert.Nil(err)
+	assert.NotEqual(string(ciphertext), secretMessage)
+	cleartext, err := rsa.DecryptOAEP(sha256.New(), rand.Reader, pk, []byte(ciphertext), []byte{})
+	assert.Nil(err)
+	assert.Equal(string(cleartext), string(secretMessage))
+}

--- a/tools/certgen/testing/certbundle.go
+++ b/tools/certgen/testing/certbundle.go
@@ -1,0 +1,16 @@
+package testing
+
+import (
+	"time"
+
+	certgenInternal "github.com/GoogleCloudPlatform/open-match/tools/certgen/internal"
+)
+
+// CreateCertificateAndPrivateKeyForTesting is for generating test certificates in unit tests.
+func CreateCertificateAndPrivateKeyForTesting(address string) ([]byte, []byte, error) {
+	return certgenInternal.CreateCertificateAndPrivateKey(&certgenInternal.Params{
+		ValidityDuration: time.Hour * 1,
+		Hostnames:        address,
+		RSAKeyLength:     2048,
+	})
+}

--- a/tools/certgen/testing/certbundle_test.go
+++ b/tools/certgen/testing/certbundle_test.go
@@ -1,0 +1,44 @@
+package testing
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	fakeAddress = "localhost:1024"
+)
+
+func TestCreateCertificateAndPrivateKeyForTestingAreValid(t *testing.T) {
+	assert := assert.New(t)
+
+	pubData, privData, err := CreateCertificateAndPrivateKeyForTesting(fakeAddress)
+	assert.Nil(err)
+
+	// Verify that we can load the public/private key pair.
+	publicKeyPemBlock, remainder := pem.Decode(pubData)
+	assert.Empty(remainder)
+	pub, err := x509.ParseCertificate(publicKeyPemBlock.Bytes)
+	assert.Nil(err)
+	assert.NotNil(pub)
+	privateKeyPemBlock, remainder := pem.Decode(privData)
+	assert.Empty(remainder)
+	pk, err := x509.ParsePKCS1PrivateKey(privateKeyPemBlock.Bytes)
+	assert.Nil(err)
+	assert.NotNil(pk)
+}
+
+func TestCreateCertificateAndPrivateKeyForTestingAreDifferent(t *testing.T) {
+	assert := assert.New(t)
+
+	pubData1, privData1, err := CreateCertificateAndPrivateKeyForTesting(fakeAddress)
+	assert.Nil(err)
+	pubData2, privData2, err := CreateCertificateAndPrivateKeyForTesting(fakeAddress)
+	assert.Nil(err)
+
+	assert.NotEqual(string(pubData1), string(pubData2))
+	assert.NotEqual(string(privData1), string(privData2))
+}


### PR DESCRIPTION
This change adds a self-signed certificate generation tool to assist with creating certificates used with gRPC TLS mode.

It's possible to use openssl as well but this is simpler since there's no CSR workflow required here.