### PR TITLE
Update gcloud.md steps to work with free tier

### DIFF
--- a/docs/gcloud.md
+++ b/docs/gcloud.md
@@ -22,5 +22,5 @@ gcloud services enable container.googleapis.com
 gcloud compute zones list
 
 # Create a GKE Cluster in this project
-gcloud container clusters create --machine-type n1-standard-4 open-match-dev-cluster --zone us-west1-a --tags open-match
+gcloud container clusters create --machine-type n1-standard-2 open-match-dev-cluster --zone us-west1-a --tags open-match
 ```


### PR DESCRIPTION
While following documentation to create a cluster for Open Match using GCP, the command line example says to create using n1-standard-4 machine type. 
It seems like it is not possible when on a free tier, at least on the default settings (new account)

`C:\Program Files (x86)\Google\Cloud SDK>gcloud container clusters create --machine-type n1-standard-4 open-match-dev-cluster --zone us-west1-a --tags open-match`

`ERROR: (gcloud.container.clusters.create) ResponseError: code=403, message=Insufficient regional quota to satisfy request: resource "CPUS": request requires '12.0' and is short '4.0'. project has a quota of '8.0' with '8.0' available. View and manage quotas at https://console.cloud.google.com/iam-admin/quotas?usage=USED&project=XXXXX`

To remove as many potential hurdles for people new to GCP, I would suggest to replace by a n1-standard-2 which works straight away.