### PR TITLE
Add ListenerHolder.AddrString() to avoid bad IPv6 assumptions. (#298) (#297)

### DIFF
--- a/internal/serving/grpcserver.go
+++ b/internal/serving/grpcserver.go
@@ -159,7 +159,7 @@ func (gw *GrpcWrapper) startHTTPProxy(wg *sync.WaitGroup) error {
 
 	proxyMux := runtime.NewServeMux()
 
-	serviceEndpoint := fmt.Sprintf("localhost:%d", gw.serviceLh.Number())
+	serviceEndpoint := gw.serviceLh.AddrString()
 	gw.grpcClient, err = grpc.DialContext(ctx, serviceEndpoint, grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
 		gw.logger.WithFields(log.Fields{
@@ -186,7 +186,7 @@ func (gw *GrpcWrapper) startHTTPProxy(wg *sync.WaitGroup) error {
 
 	go func() {
 		wg.Done()
-		gw.logger.Infof("Serving proxy on :%d", gw.proxyLh.Number())
+		gw.logger.Infof("Serving proxy on %s", gw.proxyLh.AddrString())
 		err := gw.proxy.Serve(proxyLn)
 		gw.proxyAwaiter <- err
 		if err != nil {
@@ -231,7 +231,7 @@ func (gw *GrpcWrapper) startGrpcServer(wg *sync.WaitGroup) error {
 
 	go func() {
 		wg.Done()
-		gw.logger.Infof("Serving gRPC on :%d", gw.serviceLh.Number())
+		gw.logger.Infof("Serving gRPC on %s", gw.serviceLh.AddrString())
 		err := gw.server.Serve(serviceLn)
 		gw.grpcAwaiter <- err
 		if err != nil {

--- a/internal/util/netlistener/listener_holder.go
+++ b/internal/util/netlistener/listener_holder.go
@@ -13,6 +13,7 @@ import (
 type ListenerHolder struct {
 	number   int
 	listener net.Listener
+	addr     string
 	sync.RWMutex
 }
 
@@ -31,6 +32,13 @@ func (lh *ListenerHolder) Obtain() (net.Listener, error) {
 // Number returns the port number.
 func (lh *ListenerHolder) Number() int {
 	return lh.number
+}
+
+// AddrString returns the address of the serving port.
+// Use this over fmt.Sprintf(":%d", lh.Number()) because the address is represented differently in
+// systems that prefer IPv4 and IPv6.
+func (lh *ListenerHolder) AddrString() string {
+	return lh.addr
 }
 
 // Close shutsdown the TCP listener.
@@ -59,6 +67,7 @@ func NewFromPortNumber(portNumber int) (*ListenerHolder, error) {
 		return &ListenerHolder{
 			number:   tcpConn.Port,
 			listener: conn,
+			addr:     conn.Addr().String(),
 		}, nil
 	}
 	return nil, err

--- a/internal/util/netlistener/listener_holder_test.go
+++ b/internal/util/netlistener/listener_holder_test.go
@@ -1,6 +1,8 @@
 package netlistener
 
 import (
+	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -9,6 +11,32 @@ import (
 const (
 	numIterations = 1000
 )
+
+// TestAddrString verifies that AddrString() is consistent with the port's Addr().String() value.
+func TestAddrString(t *testing.T) {
+	lh, err := NewFromPortNumber(0)
+	if err != nil {
+		t.Fatalf("NewFromPortNumber(0) had error, %s", err)
+	}
+
+	if !strings.HasSuffix(lh.AddrString(), fmt.Sprintf(":%d", lh.Number())) {
+		t.Errorf("%s does not have suffix ':%d'", lh.AddrString(), lh.Number())
+	}
+
+	port, err := lh.Obtain()
+	defer func() {
+		err := port.Close()
+		if err != nil {
+			t.Errorf("error %s while calling port.Close()", err)
+		}
+	}()
+	if err != nil {
+		t.Errorf("error %s while calling lh.Obtain", err)
+	}
+	if port.Addr().String() != lh.AddrString() {
+		t.Errorf("port.Addr().String() = %s should match lh.AddrString() = %s", port.Addr().String(), lh.AddrString())
+	}
+}
 
 // TestObtain verifies that a ListenerHolder only returns Obtain() once.
 func TestObtain(t *testing.T) {


### PR DESCRIPTION
On machines that have IP v6 enabled localhost appears as `[::]:PORT` on IPv4 it's `:PORT`. When using certgen there's issues assuming IPv4 style when using server overrides to validating certificates.
Resolves #298
Resolves #297