### PR TITLE
Move all deprecated Makefile targets to the bottom.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,3 @@
-################################################################################
-#                              Open Match Makefile                             #
-################################################################################
-
 # Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -179,57 +175,6 @@ push-mmlogic-image: docker build-mmlogic-image
 	docker push $(REGISTRY)/openmatch-mmlogic:$(TAG)
 	docker push $(REGISTRY)/openmatch-mmlogic:$(ALTERNATE_TAG)
 
-deprecated-push-images: deprecated-push-service-images deprecated-push-client-images deprecated-push-mmf-example-images deprecated-push-evaluator-example-images
-deprecated-push-service-images: deprecated-push-minimatch-image deprecated-push-frontendapi-image deprecated-push-backendapi-image deprecated-push-mmlogicapi-image
-deprecated-push-mmf-example-images: deprecated-push-mmf-go-grpc-serving-simple-image
-deprecated-push-client-images: deprecated-push-backendclient-image deprecated-push-clientloadgen-image deprecated-push-frontendclient-image
-deprecated-push-evaluator-example-images: deprecated-push-evaluator-serving-image
-
-# Deprecated
-deprecated-push-minimatch-image: docker deprecated-build-minimatch-image
-	docker push $(REGISTRY)/openmatch-minimatch:$(TAG)
-	docker push $(REGISTRY)/openmatch-minimatch:$(ALTERNATE_TAG)
-
-# Deprecated
-deprecated-push-frontendapi-image: docker deprecated-build-frontendapi-image
-	docker push $(REGISTRY)/openmatch-frontendapi:$(TAG)
-	docker push $(REGISTRY)/openmatch-frontendapi:$(ALTERNATE_TAG)
-
-# Deprecated
-deprecated-push-backendapi-image: docker deprecated-build-backendapi-image
-	docker push $(REGISTRY)/openmatch-backendapi:$(TAG)
-	docker push $(REGISTRY)/openmatch-backendapi:$(ALTERNATE_TAG)
-
-# Deprecated
-deprecated-push-mmlogicapi-image: docker deprecated-build-mmlogicapi-image
-	docker push $(REGISTRY)/openmatch-mmlogicapi:$(TAG)
-	docker push $(REGISTRY)/openmatch-mmlogicapi:$(ALTERNATE_TAG)
-
-# Deprecated
-deprecated-push-mmf-go-grpc-serving-simple-image: docker deprecated-build-mmf-go-grpc-serving-simple-image
-	docker push $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(TAG)
-	docker push $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(ALTERNATE_TAG)
-
-# Deprecated
-deprecated-push-backendclient-image: docker deprecated-build-backendclient-image
-	docker push $(REGISTRY)/openmatch-backendclient:$(TAG)
-	docker push $(REGISTRY)/openmatch-backendclient:$(ALTERNATE_TAG)
-
-# Deprecated
-deprecated-push-clientloadgen-image: docker deprecated-build-clientloadgen-image
-	docker push $(REGISTRY)/openmatch-clientloadgen:$(TAG)
-	docker push $(REGISTRY)/openmatch-clientloadgen:$(ALTERNATE_TAG)
-
-# Deprecated
-deprecated-push-frontendclient-image: docker deprecated-build-frontendclient-image
-	docker push $(REGISTRY)/openmatch-frontendclient:$(TAG)
-	docker push $(REGISTRY)/openmatch-frontendclient:$(ALTERNATE_TAG)
-
-# Deprecated
-deprecated-push-evaluator-serving-image: docker deprecated-build-evaluator-serving-image
-	docker push $(REGISTRY)/openmatch-evaluator-serving:$(TAG)
-	docker push $(REGISTRY)/openmatch-evaluator-serving:$(ALTERNATE_TAG)
-
 build-images: build-service-images deprecated-build-images
 build-service-images: build-backend-image build-frontend-image build-mmlogic-image
 
@@ -245,67 +190,12 @@ build-frontend-image: docker build-base-build-image
 build-mmlogic-image: docker build-base-build-image
 	docker build -f cmd/future/mmlogic/Dockerfile -t $(REGISTRY)/openmatch-mmlogic:$(TAG) -t $(REGISTRY)/openmatch-mmlogic:$(ALTERNATE_TAG) .
 
-# Deprecated
-deprecated-build-images: deprecated-build-service-images deprecated-build-client-images deprecated-build-mmf-example-images deprecated-build-evaluator-example-images
-deprecated-build-service-images: deprecated-build-minimatch-image deprecated-build-frontendapi-image deprecated-build-backendapi-image deprecated-build-mmlogicapi-image
-deprecated-build-client-images: deprecated-build-backendclient-image deprecated-build-clientloadgen-image deprecated-build-frontendclient-image
-deprecated-build-mmf-example-images: deprecated-build-mmf-go-grpc-serving-simple-image
-deprecated-build-evaluator-example-images: deprecated-build-evaluator-serving-image
-
-# Deprecated
-deprecated-build-minimatch-image: docker build-base-build-image
-	docker build -f cmd/minimatch/Dockerfile -t $(REGISTRY)/openmatch-minimatch:$(TAG) -t $(REGISTRY)/openmatch-minimatch:$(ALTERNATE_TAG) .
-
-# Deprecated
-deprecated-build-frontendapi-image: docker build-base-build-image
-	docker build -f cmd/frontendapi/Dockerfile -t $(REGISTRY)/openmatch-frontendapi:$(TAG) -t $(REGISTRY)/openmatch-frontendapi:$(ALTERNATE_TAG) .
-
-# Deprecated
-deprecated-build-backendapi-image: docker build-base-build-image
-	docker build -f cmd/backendapi/Dockerfile -t $(REGISTRY)/openmatch-backendapi:$(TAG) -t $(REGISTRY)/openmatch-backendapi:$(ALTERNATE_TAG) .
-
-# Deprecated
-deprecated-build-mmlogicapi-image: docker build-base-build-image
-	docker build -f cmd/mmlogicapi/Dockerfile -t $(REGISTRY)/openmatch-mmlogicapi:$(TAG) -t $(REGISTRY)/openmatch-mmlogicapi:$(ALTERNATE_TAG) .
-
-# Deprecated
-deprecated-build-mmf-go-grpc-serving-simple-image: docker build-base-build-image
-	docker build -f examples/functions/golang/grpc-serving/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(ALTERNATE_TAG) .
-
-# Deprecated
-deprecated-build-backendclient-image: docker build-base-build-image
-	docker build -f examples/backendclient/Dockerfile -t $(REGISTRY)/openmatch-backendclient:$(TAG) -t $(REGISTRY)/openmatch-backendclient:$(ALTERNATE_TAG) .
-
-# Deprecated
-deprecated-build-clientloadgen-image: docker build-base-build-image
-	docker build -f test/cmd/clientloadgen/Dockerfile -t $(REGISTRY)/openmatch-clientloadgen:$(TAG) -t $(REGISTRY)/openmatch-clientloadgen:$(ALTERNATE_TAG) .
-
-# Deprecated
-deprecated-build-frontendclient-image: docker build-base-build-image
-	docker build -f test/cmd/frontendclient/Dockerfile -t $(REGISTRY)/openmatch-frontendclient:$(TAG) -t $(REGISTRY)/openmatch-frontendclient:$(ALTERNATE_TAG) .
-
-# Deprecated
-deprecated-build-evaluator-serving-image: build-base-build-image
-	docker build -f examples/evaluators/golang/serving/Dockerfile -t $(REGISTRY)/openmatch-evaluator-serving:$(TAG) -t $(REGISTRY)/openmatch-evaluator-serving:$(ALTERNATE_TAG) .
-
-clean-images: docker
+clean-images: docker deprecated-clean-images
 	-docker rmi -f open-match-base-build
 
 	-docker rmi -f $(REGISTRY)/openmatch-backend:$(TAG) $(REGISTRY)/openmatch-backend:$(ALTERNATE_TAG)
 	-docker rmi -f $(REGISTRY)/openmatch-frontend:$(TAG) $(REGISTRY)/openmatch-frontend:$(ALTERNATE_TAG)
 	-docker rmi -f $(REGISTRY)/openmatch-mmlogic:$(TAG) $(REGISTRY)/openmatch-mmlogic:$(ALTERNATE_TAG)
-
-	-docker rmi -f $(REGISTRY)/openmatch-minimatch:$(TAG) $(REGISTRY)/openmatch-minimatch:$(ALTERNATE_TAG)
-	-docker rmi -f $(REGISTRY)/openmatch-frontendapi:$(TAG) $(REGISTRY)/openmatch-frontendapi:$(ALTERNATE_TAG)
-	-docker rmi -f $(REGISTRY)/openmatch-backendapi:$(TAG) $(REGISTRY)/openmatch-backendapi:$(ALTERNATE_TAG)
-	-docker rmi -f $(REGISTRY)/openmatch-mmlogicapi:$(TAG) $(REGISTRY)/openmatch-mmlogicapi:$(ALTERNATE_TAG)
-
-	-docker rmi -f $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(TAG) $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(ALTERNATE_TAG)
-
-	-docker rmi -f $(REGISTRY)/openmatch-backendclient:$(TAG) $(REGISTRY)/openmatch-backendclient:$(ALTERNATE_TAG)
-	-docker rmi -f $(REGISTRY)/openmatch-clientloadgen:$(TAG) $(REGISTRY)/openmatch-clientloadgen:$(ALTERNATE_TAG)
-	-docker rmi -f $(REGISTRY)/openmatch-frontendclient:$(TAG) $(REGISTRY)/openmatch-frontendclient:$(ALTERNATE_TAG)
-	-docker rmi -f $(REGISTRY)/openmatch-evaluator-serving:$(TAG) $(REGISTRY)/openmatch-evaluator-serving:$(ALTERNATE_TAG)
 
 install-redis: build/toolchain/bin/helm$(EXE_EXTENSION)
 	$(HELM) upgrade --install --wait --debug $(REDIS_NAME) stable/redis --namespace $(OPEN_MATCH_KUBERNETES_NAMESPACE)
@@ -599,41 +489,6 @@ create-mini-cluster: build/toolchain/bin/minikube$(EXE_EXTENSION)
 delete-mini-cluster: build/toolchain/bin/minikube$(EXE_EXTENSION)
 	$(MINIKUBE) delete
 
-# Deprecated
-deprecated-all-protos: deprecated-golang-protos deprecated-http-proxy-golang-protos deprecated-swagger-json-docs
-
-# Deprecated
-deprecated-golang-protos: internal/pb/backend.pb.go internal/pb/frontend.pb.go internal/pb/matchfunction.pb.go internal/pb/messages.pb.go internal/pb/mmlogic.pb.go
-
-# Deprecated
-deprecated-http-proxy-golang-protos: internal/pb/backend.pb.gw.go internal/pb/frontend.pb.gw.go internal/pb/matchfunction.pb.gw.go internal/pb/messages.pb.gw.go internal/pb/mmlogic.pb.gw.go
-
-# Deprecated
-deprecated-swagger-json-docs: api/protobuf-spec/frontend.swagger.json api/protobuf-spec/backend.swagger.json api/protobuf-spec/mmlogic.swagger.json api/protobuf-spec/matchfunction.swagger.json
-
-# Deprecated
-internal/pb/%.pb.go: api/protobuf-spec/%.proto build/toolchain/bin/protoc$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-go$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-grpc-gateway$(EXE_EXTENSION)
-	$(PROTOC) $< \
-		-I $(REPOSITORY_ROOT) -I $(PROTOC_INCLUDES) \
-		--go_out=plugins=grpc:$(REPOSITORY_ROOT)
-
-# Deprecated
-internal/pb/%.pb.gw.go: api/protobuf-spec/%.proto internal/pb/%.pb.go build/toolchain/bin/protoc$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-go$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-grpc-gateway$(EXE_EXTENSION)
-	$(PROTOC) $< \
-		-I $(REPOSITORY_ROOT) -I $(PROTOC_INCLUDES) \
-   		--grpc-gateway_out=logtostderr=true,allow_delete_body=true:$(REPOSITORY_ROOT)
-# Deprecated
-api/protobuf-spec/%.swagger.json: api/protobuf-spec/%.proto internal/pb/%.pb.gw.go build/toolchain/bin/protoc$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-swagger$(EXE_EXTENSION)
-	$(PROTOC) $< \
-		-I $(REPOSITORY_ROOT) -I $(PROTOC_INCLUDES) --swagger_out=logtostderr=true,allow_delete_body=true:$(REPOSITORY_ROOT)
-
-# Deprecated
-# Include structure of the protos needs to be called out do the dependency chain is run through properly.
-internal/pb/backend.pb.go: internal/pb/messages.pb.go
-internal/pb/frontend.pb.go: internal/pb/messages.pb.go
-internal/pb/mmlogic.pb.go: internal/pb/messages.pb.go
-internal/pb/matchfunction.pb.go: internal/pb/messages.pb.go
-
 all-protos: deprecated-all-protos golang-protos http-proxy-golang-protos swagger-json-docs
 golang-protos: internal/future/pb/backend.pb.go internal/future/pb/frontend.pb.go internal/future/pb/matchfunction.pb.go internal/future/pb/messages.pb.go internal/future/pb/mmlogic.pb.go
 
@@ -703,54 +558,6 @@ cmd/future/mmlogic/mmlogic$(EXE_EXTENSION): internal/future/pb/mmlogic.pb.go int
 
 tools/certgen/certgen$(EXE_EXTENSION):
 	cd tools/certgen/ && $(GO_BUILD_COMMAND)
-
-# Deprecated
-deprecated-all: deprecated-service-binaries deprecated-client-binaries deprecated-example-binaries tools-binaries
-deprecated-service-binaries: cmd/minimatch/minimatch$(EXE_EXTENSION) cmd/backendapi/backendapi$(EXE_EXTENSION) cmd/frontendapi/frontendapi$(EXE_EXTENSION) cmd/mmlogicapi/mmlogicapi$(EXE_EXTENSION)
-deprecated-client-binaries: examples/backendclient/backendclient$(EXE_EXTENSION) test/cmd/clientloadgen/clientloadgen$(EXE_EXTENSION) test/cmd/frontendclient/frontendclient$(EXE_EXTENSION)
-deprecated-example-binaries: deprecated-example-mmf-binaries deprecated-example-evaluator-binaries
-deprecated-example-mmf-binaries: examples/functions/golang/grpc-serving/grpc-serving$(EXE_EXTENSION)
-deprecated-example-evaluator-binaries: examples/evaluators/golang/serving/serving$(EXE_EXTENSION)
-
-# Deprecated
-# Note: This list of dependencies is long but only add file references here. If you add a .PHONY dependency make will always rebuild it.
-cmd/minimatch/minimatch$(EXE_EXTENSION): internal/pb/backend.pb.go internal/pb/backend.pb.gw.go api/protobuf-spec/backend.swagger.json
-cmd/minimatch/minimatch$(EXE_EXTENSION): internal/pb/frontend.pb.go internal/pb/frontend.pb.gw.go api/protobuf-spec/frontend.swagger.json
-cmd/minimatch/minimatch$(EXE_EXTENSION): internal/pb/mmlogic.pb.go internal/pb/mmlogic.pb.gw.go api/protobuf-spec/mmlogic.swagger.json
-cmd/minimatch/minimatch$(EXE_EXTENSION): internal/pb/messages.pb.go
-	cd cmd/minimatch; $(GO_BUILD_COMMAND)
-
-# Deprecated
-cmd/backendapi/backendapi$(EXE_EXTENSION): internal/pb/backend.pb.go internal/pb/backend.pb.gw.go api/protobuf-spec/backend.swagger.json
-	cd cmd/backendapi; $(GO_BUILD_COMMAND)
-
-# Deprecated
-cmd/frontendapi/frontendapi$(EXE_EXTENSION): internal/pb/frontend.pb.go internal/pb/frontend.pb.gw.go api/protobuf-spec/frontend.swagger.json
-	cd cmd/frontendapi; $(GO_BUILD_COMMAND)
-
-# Deprecated
-cmd/mmlogicapi/mmlogicapi$(EXE_EXTENSION): internal/pb/mmlogic.pb.go internal/pb/mmlogic.pb.gw.go api/protobuf-spec/mmlogic.swagger.json
-	cd cmd/mmlogicapi; $(GO_BUILD_COMMAND)
-
-# Deprecated
-examples/backendclient/backendclient$(EXE_EXTENSION): internal/pb/backend.pb.go
-	cd examples/backendclient; $(GO_BUILD_COMMAND)
-
-# Deprecated
-examples/evaluators/golang/serving/serving$(EXE_EXTENSION): internal/pb/messages.pb.go
-	cd examples/evaluators/golang/serving; $(GO_BUILD_COMMAND)
-
-# Deprecated
-examples/functions/golang/grpc-serving/grpc-serving$(EXE_EXTENSION): internal/pb/messages.pb.go
-	cd examples/functions/golang/grpc-serving; $(GO_BUILD_COMMAND)
-
-# Deprecated
-test/cmd/clientloadgen/clientloadgen$(EXE_EXTENSION):
-	cd test/cmd/clientloadgen; $(GO_BUILD_COMMAND)
-
-# Deprecated
-test/cmd/frontendclient/frontendclient$(EXE_EXTENSION): internal/pb/frontend.pb.go internal/pb/messages.pb.go
-	cd test/cmd/frontendclient; $(GO_BUILD_COMMAND)
 
 build/certificates/: build/toolchain/bin/certgen$(EXE_EXTENSION)
 	mkdir -p $(BUILD_DIR)/certificates/
@@ -825,26 +632,17 @@ clean-release:
 clean-site:
 	rm -rf $(REPOSITORY_ROOT)/build/site/
 
-clean-swagger-docs:
-	rm -rf $(REPOSITORY_ROOT)/api/protobuf-spec/*.json
+clean-swagger-docs: deprecated-clean-swagger-docs
+	rm -rf $(REPOSITORY_ROOT)/api/*.json
 
-clean-protos:
-	rm -rf $(REPOSITORY_ROOT)/internal/pb/
-	rm -rf $(REPOSITORY_ROOT)/api/protobuf_spec/
+clean-protos: deprecated-clean-protos
+	rm -rf $(REPOSITORY_ROOT)/internal/future/pb/
 
-clean-binaries:
+clean-binaries: deprecated-clean-binaries
 	rm -rf $(REPOSITORY_ROOT)/cmd/future/backend/backend
 	rm -rf $(REPOSITORY_ROOT)/cmd/future/frontend/frontend
 	rm -rf $(REPOSITORY_ROOT)/cmd/future/mmlogic/mmlogic
 	rm -rf $(REPOSITORY_ROOT)/cmd/minimatch/minimatch
-	rm -rf $(REPOSITORY_ROOT)/cmd/backendapi/backendapi
-	rm -rf $(REPOSITORY_ROOT)/cmd/frontendapi/frontendapi
-	rm -rf $(REPOSITORY_ROOT)/cmd/mmlogicapi/mmlogicapi
-	rm -rf $(REPOSITORY_ROOT)/examples/backendclient/backendclient
-	rm -rf $(REPOSITORY_ROOT)/examples/evaluators/golang/serving/serving
-	rm -rf $(REPOSITORY_ROOT)/examples/functions/golang/grpc-serving/grpc-serving
-	rm -rf $(REPOSITORY_ROOT)/test/cmd/clientloadgen/clientloadgen
-	rm -rf $(REPOSITORY_ROOT)/test/cmd/frontendclient/frontendclient
 
 clean-build: clean-toolchain clean-archives clean-release
 	rm -rf $(REPOSITORY_ROOT)/build/
@@ -874,15 +672,6 @@ clean-stress-test-tools:
 	rm -f $(REPOSITORY_ROOT)/test/stress/*.csv
 
 clean: clean-images clean-binaries clean-site clean-release clean-build clean-protos clean-swagger-docs clean-nodejs clean-install-yaml clean-stress-test-tools
-
-run-backendclient: build/toolchain/bin/kubectl$(EXE_EXTENSION)
-	$(KUBECTL) run om-backendclient --rm --restart=Never --image-pull-policy=Always -i --tty --image=$(REGISTRY)/openmatch-backendclient:$(TAG) --namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) $(KUBECTL_RUN_ENV)
-
-run-frontendclient: build/toolchain/bin/kubectl$(EXE_EXTENSION)
-	$(KUBECTL) run om-frontendclient --rm --restart=Never --image-pull-policy=Always -i --tty --image=$(REGISTRY)/openmatch-frontendclient:$(TAG) --namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) $(KUBECTL_RUN_ENV)
-
-run-clientloadgen: build/toolchain/bin/kubectl$(EXE_EXTENSION)
-	$(KUBECTL) run om-clientloadgen --rm --restart=Never --image-pull-policy=Always -i --tty --image=$(REGISTRY)/openmatch-clientloadgen:$(TAG) --namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) $(KUBECTL_RUN_ENV)
 
 proxy-grafana: build/toolchain/bin/kubectl$(EXE_EXTENSION)
 	echo "User: admin"
@@ -922,4 +711,226 @@ endif
 endif
 
 .PHONY: docker gcloud deploy-redirect-site update-deps sync-deps sleep-10 proxy-dashboard proxy-prometheus proxy-grafana clean clean-build clean-toolchain clean-archives clean-binaries clean-protos presubmit test ci-test vet
+
+################################################################################
+#                              Deprecated Targets                              #
+################################################################################
+
+deprecated-push-images: deprecated-push-service-images deprecated-push-client-images deprecated-push-mmf-example-images deprecated-push-evaluator-example-images
+deprecated-push-service-images: deprecated-push-minimatch-image deprecated-push-frontendapi-image deprecated-push-backendapi-image deprecated-push-mmlogicapi-image
+deprecated-push-mmf-example-images: deprecated-push-mmf-go-grpc-serving-simple-image
+deprecated-push-client-images: deprecated-push-backendclient-image deprecated-push-clientloadgen-image deprecated-push-frontendclient-image
+deprecated-push-evaluator-example-images: deprecated-push-evaluator-serving-image
+
+# Deprecated
+deprecated-push-minimatch-image: docker deprecated-build-minimatch-image
+	docker push $(REGISTRY)/openmatch-minimatch:$(TAG)
+	docker push $(REGISTRY)/openmatch-minimatch:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-push-frontendapi-image: docker deprecated-build-frontendapi-image
+	docker push $(REGISTRY)/openmatch-frontendapi:$(TAG)
+	docker push $(REGISTRY)/openmatch-frontendapi:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-push-backendapi-image: docker deprecated-build-backendapi-image
+	docker push $(REGISTRY)/openmatch-backendapi:$(TAG)
+	docker push $(REGISTRY)/openmatch-backendapi:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-push-mmlogicapi-image: docker deprecated-build-mmlogicapi-image
+	docker push $(REGISTRY)/openmatch-mmlogicapi:$(TAG)
+	docker push $(REGISTRY)/openmatch-mmlogicapi:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-push-mmf-go-grpc-serving-simple-image: docker deprecated-build-mmf-go-grpc-serving-simple-image
+	docker push $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(TAG)
+	docker push $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-push-backendclient-image: docker deprecated-build-backendclient-image
+	docker push $(REGISTRY)/openmatch-backendclient:$(TAG)
+	docker push $(REGISTRY)/openmatch-backendclient:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-push-clientloadgen-image: docker deprecated-build-clientloadgen-image
+	docker push $(REGISTRY)/openmatch-clientloadgen:$(TAG)
+	docker push $(REGISTRY)/openmatch-clientloadgen:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-push-frontendclient-image: docker deprecated-build-frontendclient-image
+	docker push $(REGISTRY)/openmatch-frontendclient:$(TAG)
+	docker push $(REGISTRY)/openmatch-frontendclient:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-push-evaluator-serving-image: docker deprecated-build-evaluator-serving-image
+	docker push $(REGISTRY)/openmatch-evaluator-serving:$(TAG)
+	docker push $(REGISTRY)/openmatch-evaluator-serving:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-build-images: deprecated-build-service-images deprecated-build-client-images deprecated-build-mmf-example-images deprecated-build-evaluator-example-images
+deprecated-build-service-images: deprecated-build-minimatch-image deprecated-build-frontendapi-image deprecated-build-backendapi-image deprecated-build-mmlogicapi-image
+deprecated-build-client-images: deprecated-build-backendclient-image deprecated-build-clientloadgen-image deprecated-build-frontendclient-image
+deprecated-build-mmf-example-images: deprecated-build-mmf-go-grpc-serving-simple-image
+deprecated-build-evaluator-example-images: deprecated-build-evaluator-serving-image
+
+# Deprecated
+deprecated-build-minimatch-image: docker build-base-build-image
+	docker build -f cmd/minimatch/Dockerfile -t $(REGISTRY)/openmatch-minimatch:$(TAG) -t $(REGISTRY)/openmatch-minimatch:$(ALTERNATE_TAG) .
+
+# Deprecated
+deprecated-build-frontendapi-image: docker build-base-build-image
+	docker build -f cmd/frontendapi/Dockerfile -t $(REGISTRY)/openmatch-frontendapi:$(TAG) -t $(REGISTRY)/openmatch-frontendapi:$(ALTERNATE_TAG) .
+
+# Deprecated
+deprecated-build-backendapi-image: docker build-base-build-image
+	docker build -f cmd/backendapi/Dockerfile -t $(REGISTRY)/openmatch-backendapi:$(TAG) -t $(REGISTRY)/openmatch-backendapi:$(ALTERNATE_TAG) .
+
+# Deprecated
+deprecated-build-mmlogicapi-image: docker build-base-build-image
+	docker build -f cmd/mmlogicapi/Dockerfile -t $(REGISTRY)/openmatch-mmlogicapi:$(TAG) -t $(REGISTRY)/openmatch-mmlogicapi:$(ALTERNATE_TAG) .
+
+# Deprecated
+deprecated-build-mmf-go-grpc-serving-simple-image: docker build-base-build-image
+	docker build -f examples/functions/golang/grpc-serving/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(ALTERNATE_TAG) .
+
+# Deprecated
+deprecated-build-backendclient-image: docker build-base-build-image
+	docker build -f examples/backendclient/Dockerfile -t $(REGISTRY)/openmatch-backendclient:$(TAG) -t $(REGISTRY)/openmatch-backendclient:$(ALTERNATE_TAG) .
+
+# Deprecated
+deprecated-build-clientloadgen-image: docker build-base-build-image
+	docker build -f test/cmd/clientloadgen/Dockerfile -t $(REGISTRY)/openmatch-clientloadgen:$(TAG) -t $(REGISTRY)/openmatch-clientloadgen:$(ALTERNATE_TAG) .
+
+# Deprecated
+deprecated-build-frontendclient-image: docker build-base-build-image
+	docker build -f test/cmd/frontendclient/Dockerfile -t $(REGISTRY)/openmatch-frontendclient:$(TAG) -t $(REGISTRY)/openmatch-frontendclient:$(ALTERNATE_TAG) .
+
+# Deprecated
+deprecated-build-evaluator-serving-image: build-base-build-image
+	docker build -f examples/evaluators/golang/serving/Dockerfile -t $(REGISTRY)/openmatch-evaluator-serving:$(TAG) -t $(REGISTRY)/openmatch-evaluator-serving:$(ALTERNATE_TAG) .
+
+deprecated-clean-images: docker
+	-docker rmi -f open-match-base-build
+
+	-docker rmi -f $(REGISTRY)/openmatch-minimatch:$(TAG) $(REGISTRY)/openmatch-minimatch:$(ALTERNATE_TAG)
+	-docker rmi -f $(REGISTRY)/openmatch-frontendapi:$(TAG) $(REGISTRY)/openmatch-frontendapi:$(ALTERNATE_TAG)
+	-docker rmi -f $(REGISTRY)/openmatch-backendapi:$(TAG) $(REGISTRY)/openmatch-backendapi:$(ALTERNATE_TAG)
+	-docker rmi -f $(REGISTRY)/openmatch-mmlogicapi:$(TAG) $(REGISTRY)/openmatch-mmlogicapi:$(ALTERNATE_TAG)
+
+	-docker rmi -f $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(TAG) $(REGISTRY)/openmatch-mmf-go-grpc-serving-simple:$(ALTERNATE_TAG)
+
+	-docker rmi -f $(REGISTRY)/openmatch-backendclient:$(TAG) $(REGISTRY)/openmatch-backendclient:$(ALTERNATE_TAG)
+	-docker rmi -f $(REGISTRY)/openmatch-clientloadgen:$(TAG) $(REGISTRY)/openmatch-clientloadgen:$(ALTERNATE_TAG)
+	-docker rmi -f $(REGISTRY)/openmatch-frontendclient:$(TAG) $(REGISTRY)/openmatch-frontendclient:$(ALTERNATE_TAG)
+	-docker rmi -f $(REGISTRY)/openmatch-evaluator-serving:$(TAG) $(REGISTRY)/openmatch-evaluator-serving:$(ALTERNATE_TAG)
+
+# Deprecated
+deprecated-all-protos: deprecated-golang-protos deprecated-http-proxy-golang-protos deprecated-swagger-json-docs
+
+# Deprecated
+deprecated-golang-protos: internal/pb/backend.pb.go internal/pb/frontend.pb.go internal/pb/matchfunction.pb.go internal/pb/messages.pb.go internal/pb/mmlogic.pb.go
+
+# Deprecated
+deprecated-http-proxy-golang-protos: internal/pb/backend.pb.gw.go internal/pb/frontend.pb.gw.go internal/pb/matchfunction.pb.gw.go internal/pb/messages.pb.gw.go internal/pb/mmlogic.pb.gw.go
+
+# Deprecated
+deprecated-swagger-json-docs: api/protobuf-spec/frontend.swagger.json api/protobuf-spec/backend.swagger.json api/protobuf-spec/mmlogic.swagger.json api/protobuf-spec/matchfunction.swagger.json
+
+# Deprecated
+internal/pb/%.pb.go: api/protobuf-spec/%.proto build/toolchain/bin/protoc$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-go$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-grpc-gateway$(EXE_EXTENSION)
+	$(PROTOC) $< \
+		-I $(REPOSITORY_ROOT) -I $(PROTOC_INCLUDES) \
+		--go_out=plugins=grpc:$(REPOSITORY_ROOT)
+
+# Deprecated
+internal/pb/%.pb.gw.go: api/protobuf-spec/%.proto internal/pb/%.pb.go build/toolchain/bin/protoc$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-go$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-grpc-gateway$(EXE_EXTENSION)
+	$(PROTOC) $< \
+		-I $(REPOSITORY_ROOT) -I $(PROTOC_INCLUDES) \
+   		--grpc-gateway_out=logtostderr=true,allow_delete_body=true:$(REPOSITORY_ROOT)
+# Deprecated
+api/protobuf-spec/%.swagger.json: api/protobuf-spec/%.proto internal/pb/%.pb.gw.go build/toolchain/bin/protoc$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-swagger$(EXE_EXTENSION)
+	$(PROTOC) $< \
+		-I $(REPOSITORY_ROOT) -I $(PROTOC_INCLUDES) --swagger_out=logtostderr=true,allow_delete_body=true:$(REPOSITORY_ROOT)
+
+# Deprecated
+# Include structure of the protos needs to be called out do the dependency chain is run through properly.
+internal/pb/backend.pb.go: internal/pb/messages.pb.go
+internal/pb/frontend.pb.go: internal/pb/messages.pb.go
+internal/pb/mmlogic.pb.go: internal/pb/messages.pb.go
+internal/pb/matchfunction.pb.go: internal/pb/messages.pb.go
+
+# Deprecated
+deprecated-all: deprecated-service-binaries deprecated-client-binaries deprecated-example-binaries tools-binaries
+deprecated-service-binaries: cmd/minimatch/minimatch$(EXE_EXTENSION) cmd/backendapi/backendapi$(EXE_EXTENSION) cmd/frontendapi/frontendapi$(EXE_EXTENSION) cmd/mmlogicapi/mmlogicapi$(EXE_EXTENSION)
+deprecated-client-binaries: examples/backendclient/backendclient$(EXE_EXTENSION) test/cmd/clientloadgen/clientloadgen$(EXE_EXTENSION) test/cmd/frontendclient/frontendclient$(EXE_EXTENSION)
+deprecated-example-binaries: deprecated-example-mmf-binaries deprecated-example-evaluator-binaries
+deprecated-example-mmf-binaries: examples/functions/golang/grpc-serving/grpc-serving$(EXE_EXTENSION)
+deprecated-example-evaluator-binaries: examples/evaluators/golang/serving/serving$(EXE_EXTENSION)
+
+# Deprecated
+# Note: This list of dependencies is long but only add file references here. If you add a .PHONY dependency make will always rebuild it.
+cmd/minimatch/minimatch$(EXE_EXTENSION): internal/pb/backend.pb.go internal/pb/backend.pb.gw.go api/protobuf-spec/backend.swagger.json
+cmd/minimatch/minimatch$(EXE_EXTENSION): internal/pb/frontend.pb.go internal/pb/frontend.pb.gw.go api/protobuf-spec/frontend.swagger.json
+cmd/minimatch/minimatch$(EXE_EXTENSION): internal/pb/mmlogic.pb.go internal/pb/mmlogic.pb.gw.go api/protobuf-spec/mmlogic.swagger.json
+cmd/minimatch/minimatch$(EXE_EXTENSION): internal/pb/messages.pb.go
+	cd cmd/minimatch; $(GO_BUILD_COMMAND)
+
+# Deprecated
+cmd/backendapi/backendapi$(EXE_EXTENSION): internal/pb/backend.pb.go internal/pb/backend.pb.gw.go api/protobuf-spec/backend.swagger.json
+	cd cmd/backendapi; $(GO_BUILD_COMMAND)
+
+# Deprecated
+cmd/frontendapi/frontendapi$(EXE_EXTENSION): internal/pb/frontend.pb.go internal/pb/frontend.pb.gw.go api/protobuf-spec/frontend.swagger.json
+	cd cmd/frontendapi; $(GO_BUILD_COMMAND)
+
+# Deprecated
+cmd/mmlogicapi/mmlogicapi$(EXE_EXTENSION): internal/pb/mmlogic.pb.go internal/pb/mmlogic.pb.gw.go api/protobuf-spec/mmlogic.swagger.json
+	cd cmd/mmlogicapi; $(GO_BUILD_COMMAND)
+
+# Deprecated
+examples/backendclient/backendclient$(EXE_EXTENSION): internal/pb/backend.pb.go
+	cd examples/backendclient; $(GO_BUILD_COMMAND)
+
+# Deprecated
+examples/evaluators/golang/serving/serving$(EXE_EXTENSION): internal/pb/messages.pb.go
+	cd examples/evaluators/golang/serving; $(GO_BUILD_COMMAND)
+
+# Deprecated
+examples/functions/golang/grpc-serving/grpc-serving$(EXE_EXTENSION): internal/pb/messages.pb.go
+	cd examples/functions/golang/grpc-serving; $(GO_BUILD_COMMAND)
+
+# Deprecated
+test/cmd/clientloadgen/clientloadgen$(EXE_EXTENSION):
+	cd test/cmd/clientloadgen; $(GO_BUILD_COMMAND)
+
+# Deprecated
+test/cmd/frontendclient/frontendclient$(EXE_EXTENSION): internal/pb/frontend.pb.go internal/pb/messages.pb.go
+	cd test/cmd/frontendclient; $(GO_BUILD_COMMAND)
+
+deprecated-clean-swagger-docs:
+	rm -rf $(REPOSITORY_ROOT)/api/protobuf-spec/*.json
+
+deprecated-clean-protos:
+	rm -rf $(REPOSITORY_ROOT)/internal/pb/
+	rm -rf $(REPOSITORY_ROOT)/api/protobuf_spec/
+
+deprecated-clean-binaries:
+	rm -rf $(REPOSITORY_ROOT)/cmd/backendapi/backendapi
+	rm -rf $(REPOSITORY_ROOT)/cmd/frontendapi/frontendapi
+	rm -rf $(REPOSITORY_ROOT)/cmd/mmlogicapi/mmlogicapi
+	rm -rf $(REPOSITORY_ROOT)/examples/backendclient/backendclient
+	rm -rf $(REPOSITORY_ROOT)/examples/evaluators/golang/serving/serving
+	rm -rf $(REPOSITORY_ROOT)/examples/functions/golang/grpc-serving/grpc-serving
+	rm -rf $(REPOSITORY_ROOT)/test/cmd/clientloadgen/clientloadgen
+	rm -rf $(REPOSITORY_ROOT)/test/cmd/frontendclient/frontendclient
+
+run-backendclient: build/toolchain/bin/kubectl$(EXE_EXTENSION)
+	$(KUBECTL) run om-backendclient --rm --restart=Never --image-pull-policy=Always -i --tty --image=$(REGISTRY)/openmatch-backendclient:$(TAG) --namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) $(KUBECTL_RUN_ENV)
+
+run-frontendclient: build/toolchain/bin/kubectl$(EXE_EXTENSION)
+	$(KUBECTL) run om-frontendclient --rm --restart=Never --image-pull-policy=Always -i --tty --image=$(REGISTRY)/openmatch-frontendclient:$(TAG) --namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) $(KUBECTL_RUN_ENV)
+
+run-clientloadgen: build/toolchain/bin/kubectl$(EXE_EXTENSION)
+	$(KUBECTL) run om-clientloadgen --rm --restart=Never --image-pull-policy=Always -i --tty --image=$(REGISTRY)/openmatch-clientloadgen:$(TAG) --namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) $(KUBECTL_RUN_ENV)
 


### PR DESCRIPTION
As we move away from the old binaries we should have their build targets easy to differentiate from the new targets.

All the deprecated targets are now prefixed with `deprecated-` (where possible) and are moved to the bottom of the `Makefile`.