### PR TITLE
Replace helm chart for the new binaries.

### DIFF
--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.openmatch.frontendapi.install }}
+{{- if .Values.openmatch.backend.install }}
 kind: Service
 apiVersion: v1
 metadata:
-  name: om-frontendapi
+  name: om-backend
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "openmatch.name" . }}
@@ -24,31 +24,30 @@ metadata:
 spec:
   selector:
     app: {{ template "openmatch.name" . }}
-    component: frontend
-    {{- include "openmatch.chartmeta" (set . "indent" 4) }}
+    component: backend
   ports:
   - name: grpc
     protocol: TCP
-    port: {{ .Values.openmatch.frontendapi.grpc.port }}
+    port: {{ .Values.openmatch.backend.grpc.port }}
   - name: proxy
     protocol: TCP
-    port: {{ .Values.openmatch.frontendapi.proxy.port }}
+    port: {{ .Values.openmatch.backend.proxy.port }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: om-frontendapi
+  name: om-backend
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "openmatch.name" . }}
-    component: frontend
+    component: backend
     {{- include "openmatch.chartmeta" (set . "indent" 4) }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: {{ template "openmatch.name" . }}
-      component: frontend
+      component: backend
       {{- include "openmatch.chartmeta" (set . "indent" 6) }}
   template:
     metadata:
@@ -57,24 +56,24 @@ spec:
         {{- include "prometheus.annotations" . | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
-        component: frontend
+        component: backend
         {{- include "openmatch.chartmeta" (set . "indent" 8) }}
     spec:
       containers:
-      - name: om-frontendapi
-        image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.frontendapi.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.frontendapi.pullPolicy }}
+      - name: om-backend
+        image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.backend.name}}:{{ .Values.openmatch.image.tag }}"
+        imagePullPolicy: {{ .Values.openmatch.image.backend.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}
         ports:
         - name: grpc
-          containerPort: {{ .Values.openmatch.frontendapi.grpc.port }}
+          containerPort: {{ .Values.openmatch.backend.grpc.port }}
         - name: proxy
-          containerPort: {{ .Values.openmatch.frontendapi.proxy.port }}
+          containerPort: {{ .Values.openmatch.backend.proxy.port }}
         - name: metrics
           containerPort: {{ .Values.openmatch.metrics.port }}
-        {{- $port := dict "port" .Values.openmatch.frontendapi.proxy.port -}}
+        {{- $port := dict "port" .Values.openmatch.backend.proxy.port -}}
         {{- include "probe.readiness" $port | nindent 8 }}
         resources:
           requests:

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.openmatch.backendapi.install }}
+{{- if .Values.openmatch.frontend.install }}
 kind: Service
 apiVersion: v1
 metadata:
-  name: om-backendapi
+  name: om-frontend
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "openmatch.name" . }}
@@ -24,30 +24,31 @@ metadata:
 spec:
   selector:
     app: {{ template "openmatch.name" . }}
-    component: backend
+    component: frontend
+    {{- include "openmatch.chartmeta" (set . "indent" 4) }}
   ports:
   - name: grpc
     protocol: TCP
-    port: {{ .Values.openmatch.backendapi.grpc.port }}
+    port: {{ .Values.openmatch.frontend.grpc.port }}
   - name: proxy
     protocol: TCP
-    port: {{ .Values.openmatch.backendapi.proxy.port }}
+    port: {{ .Values.openmatch.frontend.proxy.port }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: om-backendapi
+  name: om-frontend
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "openmatch.name" . }}
-    component: backend
+    component: frontend
     {{- include "openmatch.chartmeta" (set . "indent" 4) }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: {{ template "openmatch.name" . }}
-      component: backend
+      component: frontend
       {{- include "openmatch.chartmeta" (set . "indent" 6) }}
   template:
     metadata:
@@ -56,24 +57,24 @@ spec:
         {{- include "prometheus.annotations" . | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
-        component: backend
+        component: frontend
         {{- include "openmatch.chartmeta" (set . "indent" 8) }}
     spec:
       containers:
-      - name: om-backend
-        image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.backendapi.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.backendapi.pullPolicy }}
+      - name: om-frontend
+        image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.frontend.name}}:{{ .Values.openmatch.image.tag }}"
+        imagePullPolicy: {{ .Values.openmatch.image.frontend.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}
         ports:
         - name: grpc
-          containerPort: {{ .Values.openmatch.backendapi.grpc.port }}
+          containerPort: {{ .Values.openmatch.frontend.grpc.port }}
         - name: proxy
-          containerPort: {{ .Values.openmatch.backendapi.proxy.port }}
+          containerPort: {{ .Values.openmatch.frontend.proxy.port }}
         - name: metrics
           containerPort: {{ .Values.openmatch.metrics.port }}
-        {{- $port := dict "port" .Values.openmatch.backendapi.proxy.port -}}
+        {{- $port := dict "port" .Values.openmatch.frontend.proxy.port -}}
         {{- include "probe.readiness" $port | nindent 8 }}
         resources:
           requests:

--- a/install/helm/open-match/templates/mmlogic.yaml
+++ b/install/helm/open-match/templates/mmlogic.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.openmatch.mmlogicapi.install }}
+{{- if .Values.openmatch.mmlogic.install }}
 kind: Service
 apiVersion: v1
 metadata:
-  name: om-mmlogicapi
+  name: om-mmlogic
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "openmatch.name" . }}
@@ -29,15 +29,15 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: {{ .Values.openmatch.mmlogicapi.grpc.port }}
+    port: {{ .Values.openmatch.mmlogic.grpc.port }}
   - name: proxy
     protocol: TCP
-    port: {{ .Values.openmatch.mmlogicapi.proxy.port }}
+    port: {{ .Values.openmatch.mmlogic.proxy.port }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: om-mmlogicapi
+  name: om-mmlogic
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "openmatch.name" . }}
@@ -62,19 +62,19 @@ spec:
     spec:
       containers:
       - name: om-mmlogic
-        image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.mmlogicapi.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.mmlogicapi.pullPolicy }}
+        image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.mmlogic.name}}:{{ .Values.openmatch.image.tag }}"
+        imagePullPolicy: {{ .Values.openmatch.image.mmlogic.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}
         ports:
         - name: grpc
-          containerPort: {{ .Values.openmatch.mmlogicapi.grpc.port }}
+          containerPort: {{ .Values.openmatch.mmlogic.grpc.port }}
         - name: proxy
-          containerPort: {{ .Values.openmatch.mmlogicapi.proxy.port }}
+          containerPort: {{ .Values.openmatch.mmlogic.proxy.port }}
         - name: metrics
           containerPort: {{ .Values.openmatch.metrics.port }}
-        {{- $port := dict "port" .Values.openmatch.mmlogicapi.proxy.port -}}
+        {{- $port := dict "port" .Values.openmatch.mmlogic.proxy.port -}}
         {{- include "probe.readiness" $port | nindent 8 }}
         resources:
           requests:

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -20,19 +20,19 @@ openmatch:
     stackdriverProjectID: ""
     port: 9555
     path: "/metrics"
-  backendapi:
+  backend:
     install: true
     grpc:
       port: 50505
     proxy:
       port: 51505
-  frontendapi:
+  frontend:
     install: true
     grpc:
       port: 50504
     proxy:
       port: 51504
-  mmlogicapi:
+  mmlogic:
     install: true
     grpc:
       port: 50503
@@ -56,64 +56,64 @@ openmatch:
           format: text
           source: false
 
-        api: 
-          backend: 
-            hostname: om-backendapi
-            port: "{{.Values.openmatch.backendapi.grpc.port}}"
-            proxyport: "{{.Values.openmatch.backendapi.proxy.port}}"
+        api:
+          backend:
+            hostname: om-backend
+            port: "{{.Values.openmatch.backend.grpc.port}}"
+            proxyport: "{{.Values.openmatch.backend.proxy.port}}"
             backoff: "[2 32] *2 ~0.33 <30"
-          frontend: 
-            hostname: om-frontendapi
-            port: "{{.Values.openmatch.frontendapi.grpc.port}}"
-            proxyport: "{{.Values.openmatch.frontendapi.proxy.port}}"
+          frontend:
+            hostname: om-frontend
+            port: "{{.Values.openmatch.frontend.grpc.port}}"
+            proxyport: "{{.Values.openmatch.frontend.proxy.port}}"
             backoff: "[2 32] *2 ~0.33 <300"
-          mmlogic: 
-            hostname: om-mmlogicapi
-            port: "{{.Values.openmatch.mmlogicapi.grpc.port}}"
-            proxyport: "{{.Values.openmatch.mmlogicapi.proxy.port}}"
+          mmlogic:
+            hostname: om-mmlogic
+            port: "{{.Values.openmatch.mmlogic.grpc.port}}"
+            proxyport: "{{.Values.openmatch.mmlogic.proxy.port}}"
           functions:
             port: "{{.Values.openmatch.functions.grpc.port}}"
             proxyport: "{{.Values.openmatch.functions.proxy.port}}"
-          
-        evalutor: 
+
+        evalutor:
           pollIntervalMs: 1000
           maxWaitMs: 10000
 
-        metrics: 
+        metrics:
           port: "{{.Values.openmatch.metrics.port}}"
           endpoint: "{{.Values.openmatch.metrics.path}}"
           reportingPeriod: 5
 
-        queues: 
-          proposals: 
+        queues:
+          proposals:
             name: proposalq
-          
-        ignoreLists: 
-          proposed: 
+
+        ignoreLists:
+          proposed:
             name: proposed
             offset: 0
             duration: 800
-          deindexed: 
+          deindexed:
             name: deindexed
             offset: 0
             duration: 800
-          expired: 
+          expired:
             name: OM_METADATA.accessed
             offset: 800
-            duration: 0 
+            duration: 0
 
-        redis: 
-          pool: 
+        redis:
+          pool:
             maxIdle: 3
             maxActive: 0
             idleTimeout: 60
           queryArgs:
             count: 10000
-          results: 
+          results:
             pageSize: 10000
-          expirations: 
+          expirations:
             player: 43200
-            matchobject: 43200 
+            matchobject: 43200
 
         jsonkeys:
           rosters: properties.rosters
@@ -141,14 +141,14 @@ openmatch:
   image:
     registry: gcr.io/open-match-public-images
     tag: 0.0.0-dev
-    backendapi:
-      name: openmatch-backendapi
+    backend:
+      name: openmatch-backend
       pullPolicy: Always
-    frontendapi:
-      name: openmatch-frontendapi
+    frontend:
+      name: openmatch-frontend
       pullPolicy: Always
-    mmlogicapi:
-      name: openmatch-mmlogicapi
+    mmlogic:
+      name: openmatch-mmlogic
       pullPolicy: Always
 
 # https://hub.helm.sh/charts/stable/redis


### PR DESCRIPTION
This change adjusts the helm chart to point to the new binaries when creating an Open Match cluster.

The example has not been changed yet since there's no example clients yet.