### PR TITLE
Add stubbed abstracted Redis client.

### DIFF
--- a/internal/future/storage/public.go
+++ b/internal/future/storage/public.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"github.com/GoogleCloudPlatform/open-match/internal/config"
+	"github.com/gomodule/redigo/redis"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	publicLogger = logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "storage.public",
+	})
+)
+
+// Service is a generic interface for talking to a storage backend.
+type Service interface {
+	// Close shutsdown the database connection.
+	Close() error
+}
+
+// New creates a Service based on the configuration.
+func New(cfg config.View) (Service, error) {
+	return newRedis(cfg)
+}
+
+// GetDeprecatedRedisPool returns a Redigo Redis pool.
+// This method is used to allow code to be ported over to the new storage.Service APIs iteratively.
+// This method will be going away after the 0.6.0 release.
+func GetDeprecatedRedisPool(service Service) *redis.Pool {
+	rb, ok := service.(*redisBackend)
+	if !ok {
+		publicLogger.Warningf("storage.Service was assumed to be *redisBackend but was %T instead, returning nil.", service)
+		return nil
+	}
+	return rb.redisPool
+}

--- a/internal/future/storage/redis.go
+++ b/internal/future/storage/redis.go
@@ -1,0 +1,126 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/GoogleCloudPlatform/open-match/internal/config"
+	"github.com/gomodule/redigo/redis"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	redisLogger = logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "storage.redis",
+	})
+)
+
+type redisBackend struct {
+	redisPool *redis.Pool
+}
+
+func (rb *redisBackend) Close() error {
+	return rb.redisPool.Close()
+}
+
+func (rb *redisBackend) GetDeprecatedRedisPool() *redis.Pool {
+	return rb.redisPool
+}
+
+func (rb *redisBackend) Put(ctx context.Context, key string, values map[string]string) (string, error) {
+	return rb.tx(ctx, "HSET", key, values)
+}
+
+func (rb *redisBackend) Get(ctx context.Context, key string) (string, error) {
+	return rb.tx(ctx, "GET", key, map[string]string{})
+}
+
+func (rb *redisBackend) tx(ctx context.Context, command string, key string, values map[string]string) (string, error) {
+	redisConn, err := rb.getConnection(ctx)
+	if err != nil {
+		return "", err
+	}
+	defer redisConn.Close()
+	redisLogger.WithFields(logrus.Fields{
+		"command": command,
+		"key":     key,
+		"values":  values,
+	}).Debug("Redis transaction")
+
+	cmdArgs := make([]interface{}, 0)
+	cmdArgs = append(cmdArgs, key)
+	for field, value := range values {
+		cmdArgs = append(cmdArgs, field, value)
+	}
+
+	return redis.String(redisConn.Do(command, cmdArgs...))
+}
+
+func (rb *redisBackend) getConnection(ctx context.Context) (redis.Conn, error) {
+	redisConn, err := rb.redisPool.GetContext(ctx)
+	if err != nil {
+		return nil, status.New(codes.Unavailable, err.Error()).Err()
+	}
+	return redisConn, nil
+}
+
+// NewRedis creates a storage.Service backed by Redis database.
+func newRedis(cfg config.View) (Service, error) {
+	// As per https://www.iana.org/assignments/uri-schemes/prov/redis
+	// redis://user:secret@localhost:6379/0?foo=bar&qux=baz
+
+	// Add redis user and password to connection url if they exist
+	redisURL := "redis://"
+	maskedURL := redisURL
+	if cfg.IsSet("redis.password") && cfg.GetString("redis.password") != "" {
+		redisURL += cfg.GetString("redis.user") + ":" + cfg.GetString("redis.password") + "@"
+		maskedURL += cfg.GetString("redis.user") + ":******@"
+	}
+	redisURL += cfg.GetString("redis.hostname") + ":" + cfg.GetString("redis.port")
+	maskedURL += cfg.GetString("redis.hostname") + ":" + cfg.GetString("redis.port")
+
+	redisLogger.WithField("redisURL", maskedURL).Debug("Attempting to connect to Redis")
+	pool := &redis.Pool{
+		MaxIdle:     cfg.GetInt("redis.pool.maxIdle"),
+		MaxActive:   cfg.GetInt("redis.pool.maxActive"),
+		IdleTimeout: cfg.GetDuration("redis.pool.idleTimeout") * time.Second,
+		Dial:        func() (redis.Conn, error) { return redis.DialURL(redisURL) },
+	}
+
+	// Sanity check that connection works before passing it back.  Redigo
+	// always returns a valid connection, and will just fail on the first
+	// query: https://godoc.org/github.com/gomodule/redigo/redis#Pool.Get
+	redisConn := pool.Get()
+	defer redisConn.Close()
+	_, err := redisConn.Do("SELECT", "0")
+	// Encountered an issue getting a connection from the pool.
+	if err != nil {
+		redisLogger.WithFields(logrus.Fields{
+			"error": err.Error(),
+			"query": "SELECT 0"}).Error("state storage connection error")
+		return nil, fmt.Errorf("cannot connect to Redis at %s, %s", maskedURL, err)
+	}
+
+	redisLogger.Info("Connected to Redis")
+	return &redisBackend{
+		redisPool: pool,
+	}, nil
+}

--- a/internal/future/storage/redis_test.go
+++ b/internal/future/storage/redis_test.go
@@ -1,0 +1,65 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisConnection(t *testing.T) {
+	assert := assert.New(t)
+	rb, closer := createRedis(t)
+	defer closer()
+	assert.NotNil(rb)
+	assert.Nil(closer())
+}
+
+func TestRedisGetSet(t *testing.T) {
+	assert := assert.New(t)
+	rb, closer := createRedis(t)
+
+	assert.NotNil(rb)
+
+	assert.Nil(closer())
+}
+
+func createRedis(t *testing.T) (Service, func() error) {
+	cfg := viper.New()
+	mredis, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("cannot create redis %s", err)
+	}
+
+	cfg.Set("redis.hostname", mredis.Host())
+	cfg.Set("redis.port", mredis.Port())
+	cfg.Set("redis.pool.maxIdle", 1000)
+	cfg.Set("redis.pool.idleTimeout", time.Second)
+	cfg.Set("redis.pool.maxActive", 1000)
+
+	rs, err := newRedis(cfg)
+	if err != nil {
+		t.Fatalf("cannot connect to fake redis %s", err)
+	}
+	return rs, func() error {
+		rbCloseErr := rs.Close()
+		mredis.Close()
+		return rbCloseErr
+	}
+}

--- a/internal/future/storage/redis_test.go
+++ b/internal/future/storage/redis_test.go
@@ -31,15 +31,6 @@ func TestRedisConnection(t *testing.T) {
 	assert.Nil(closer())
 }
 
-func TestRedisGetSet(t *testing.T) {
-	assert := assert.New(t)
-	rb, closer := createRedis(t)
-
-	assert.NotNil(rb)
-
-	assert.Nil(closer())
-}
-
 func createRedis(t *testing.T) (Service, func() error) {
 	cfg := viper.New()
 	mredis, err := miniredis.Run()


### PR DESCRIPTION
This is a very basic and unused Redis abstracted layer for data access.

It provides basic API to put and get data. It also has a method to get the redis connection pool directly for old code.