### PR TITLE
Instructions for v0.5.0 are not working.  Reverting to 0.5.0-rc.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-ad
 kubectl create namespace open-match
 
 # Install the core Open Match and monitoring services.
-kubectl apply -f https://github.com/GoogleCloudPlatform/open-match/releases/download/v0.5.0/install.yaml --namespace open-match
+kubectl apply -f https://github.com/GoogleCloudPlatform/open-match/releases/download/0.5.0-rc.2/install.yaml --namespace open-match
 ```
 
 ### Deploy demo components
@@ -48,7 +48,7 @@ Open Match framework requires the user to author a custom match function and an 
 
 ```bash
 # Install the example MMF and Evaluator.
-kubectl apply -f https://github.com/GoogleCloudPlatform/open-match/releases/download/v0.5.0/install-example.yaml --namespace open-match
+kubectl apply -f https://github.com/GoogleCloudPlatform/open-match/releases/download/0.5.0-rc.2/install-example.yaml --namespace open-match
 ```
 
 This command also deploys a component that continuously generates players with different properties and adds them to Open Match state storage. This is because a populated player pool is required to generate matches.


### PR DESCRIPTION
The install.yaml and install-example.yaml for v0.5.0 point to images that don't exist.  This results in an ImagePullBackOff on the pods.  Changing the README instructions to point to 0.5.0-rc.2 for now until the issue is fixed.

