### PR TITLE
Fix URLs, Post Submit, add gofmt to presubmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Open Match](site/static/images/logo-with-name.png)
 
-[![GoDoc](https://godoc.org/github.com/GoogleCloudPlatform/open-match?status.svg)](https://godoc.org/github.com/GoogleCloudPlatform/open-match)
-[![Go Report Card](https://goreportcard.com/badge/github.com/GoogleCloudPlatform/open-match)](https://goreportcard.com/report/github.com/GoogleCloudPlatform/open-match)
+[![GoDoc](https://godoc.org/open-match.dev/open-match?status.svg)](https://godoc.org/open-match.dev/open-match)
+[![Go Report Card](https://goreportcard.com/badge/open-match.dev/open-match)](https://goreportcard.com/report/open-match.dev/open-match)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/GoogleCloudPlatform/open-match/blob/master/LICENSE)
 [![GitHub release](https://img.shields.io/github/release-pre/GoogleCloudPlatform/open-match.svg)](https://github.com/GoogleCloudPlatform/open-match/releases)
 [![Follow on Twitter](https://img.shields.io/twitter/follow/Open_Match.svg?style=social&logo=twitter)](https://twitter.com/intent/follow?screen_name=Open_Match)

--- a/doc.go
+++ b/doc.go
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 // Package openmatch provides flexible, extensible, and scalable video game matchmaking.
-package openmatch
+package openmatch // import "open-match.dev/open-match"

--- a/internal/future/statestore/public.go
+++ b/internal/future/statestore/public.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gomodule/redigo/redis"
 	"github.com/sirupsen/logrus"
 	"open-match.dev/open-match/internal/config"
-	"open-match.dev/open-match/internal/future/pb"	
+	"open-match.dev/open-match/internal/future/pb"
 )
 
 var (
@@ -32,7 +32,7 @@ var (
 
 // Service is a generic interface for talking to a storage backend.
 type Service interface {
-	// CreateTicket creates a new Ticket in the state storage. This method fails if the Ticket already exists. 
+	// CreateTicket creates a new Ticket in the state storage. This method fails if the Ticket already exists.
 	CreateTicket(ctx context.Context, ticket pb.Ticket, ttl int) error
 
 	// GetTicket gets the Ticket with the specified id from state storage. This method fails if the Ticket does not exist.
@@ -47,7 +47,7 @@ type Service interface {
 	// DeindexTicket removes the indexing for the specified Ticket. Only the indexes are removed but the Ticket continues to exist.
 	DeindexTicket(ctx context.Context, id string, indices []string) error
 
-	// FilterTickets returns the Ticket ids for the Tickets meeting the specified filtering criteria. 
+	// FilterTickets returns the Ticket ids for the Tickets meeting the specified filtering criteria.
 	FilterTickets(ctx context.Context, filters []pb.Filter) ([]string, error)
 
 	// Closes the connection to the underlying storage.

--- a/internal/serving/bindata/backend/bindata.go
+++ b/internal/serving/bindata/backend/bindata.go
@@ -224,7 +224,7 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"backend.swagger.json": &bintree{backendSwaggerJson, map[string]*bintree{}},
+	"backend.swagger.json": {backendSwaggerJson, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/internal/serving/bindata/frontend/bindata.go
+++ b/internal/serving/bindata/frontend/bindata.go
@@ -224,7 +224,7 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"frontend.swagger.json": &bintree{frontendSwaggerJson, map[string]*bintree{}},
+	"frontend.swagger.json": {frontendSwaggerJson, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/internal/serving/bindata/matchfunction/bindata.go
+++ b/internal/serving/bindata/matchfunction/bindata.go
@@ -224,7 +224,7 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"matchfunction.swagger.json": &bintree{matchfunctionSwaggerJson, map[string]*bintree{}},
+	"matchfunction.swagger.json": {matchfunctionSwaggerJson, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/internal/serving/bindata/mmlogic/bindata.go
+++ b/internal/serving/bindata/mmlogic/bindata.go
@@ -224,7 +224,7 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"mmlogic.swagger.json": &bintree{mmlogicSwaggerJson, map[string]*bintree{}},
+	"mmlogic.swagger.json": {mmlogicSwaggerJson, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory.

--- a/internal/serving/testing/minimatch_test.go
+++ b/internal/serving/testing/minimatch_test.go
@@ -33,7 +33,7 @@ import (
 func TestNewMiniMatch(t *goTesting.T) {
 	ff := &FakeFrontend{}
 	mm, closer, err := NewMiniMatch([]*serving.ServerParams{
-		&serving.ServerParams{
+		{
 			BaseLogFields: logrus.Fields{
 				"app":       "openmatch",
 				"component": "frontend",

--- a/site/handler.go
+++ b/site/handler.go
@@ -174,8 +174,8 @@ func (h *handler) Host(r *http.Request) string {
 // This is ok because we are not serving executable code (javascript) from these locations, only configuration.
 func (h *handler) withCors(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-    w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-    w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 }
 
 var vanityTmpl = template.Must(template.New("vanity").Parse(`<!DOCTYPE html>

--- a/site/redirect/redirection.go
+++ b/site/redirect/redirection.go
@@ -182,8 +182,8 @@ func (h *handler) serveIndex(w http.ResponseWriter, r *http.Request) {
 // This is ok because we are not serving executable code (javascript) from these locations, only configuration.
 func (h *handler) withCors(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-    w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-    w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	w.Header().Set("Access-Control-Allow-Headers", "Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 }
 
 func (h *handler) Host(r *http.Request) string {


### PR DESCRIPTION
* Enforce `import open-match.dev/open-match`. `import github.com/GoogleCloudPlatform/open-match` is now blocked.
* Fixed bug in post submit where default website crashes the build and can hang if there's a TTY.
* Add gofmt to `make fmt` and `make presubmit` to auto fix some golangci issues.
* Fix outdated URLs in the `README.md` badges.

Verified the build site via `make _GCB_POST_SUBMIT=1 _GCB_LATEST_VERSION=0.0 ci-deploy-site`