### PR TITLE
Rename serving functions and params with 'Server' prefix

### DIFF
--- a/internal/app/backend/backend.go
+++ b/internal/app/backend/backend.go
@@ -37,7 +37,7 @@ func RunApplication() {
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
-	p, err := rpc.NewParamsFromConfig(cfg, "api.backend")
+	p, err := rpc.NewServerParamsFromConfig(cfg, "api.backend")
 	if err != nil {
 		backendLogger.WithFields(logrus.Fields{
 			"error": err.Error(),
@@ -54,7 +54,7 @@ func RunApplication() {
 }
 
 // BindService creates the backend service and binds it to the serving harness.
-func BindService(p *rpc.Params, cfg config.View) error {
+func BindService(p *rpc.ServerParams, cfg config.View) error {
 	service, err := newBackend(cfg)
 	if err != nil {
 		return err

--- a/internal/app/backend/backend_test.go
+++ b/internal/app/backend/backend_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestServerBinding(t *testing.T) {
-	bs := func(p *rpc.Params) {
+	bs := func(p *rpc.ServerParams) {
 		p.AddHandleFunc(func(s *grpc.Server) {
 			pb.RegisterBackendServer(s, &backendService{})
 		}, pb.RegisterBackendHandlerFromEndpoint)

--- a/internal/app/frontend/frontend.go
+++ b/internal/app/frontend/frontend.go
@@ -37,7 +37,7 @@ func RunApplication() {
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
-	p, err := rpc.NewParamsFromConfig(cfg, "api.frontend")
+	p, err := rpc.NewServerParamsFromConfig(cfg, "api.frontend")
 	if err != nil {
 		frontendLogger.WithFields(logrus.Fields{
 			"error": err.Error(),
@@ -54,7 +54,7 @@ func RunApplication() {
 }
 
 // BindService creates the frontend service and binds it to the serving harness.
-func BindService(p *rpc.Params, cfg config.View) error {
+func BindService(p *rpc.ServerParams, cfg config.View) error {
 	service, err := newFrontend(cfg)
 	if err != nil {
 		return err

--- a/internal/app/frontend/frontend_test.go
+++ b/internal/app/frontend/frontend_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestServerBinding(t *testing.T) {
-	bs := func(p *rpc.Params) {
+	bs := func(p *rpc.ServerParams) {
 		p.AddHandleFunc(func(s *grpc.Server) {
 			pb.RegisterFrontendServer(s, &frontendService{})
 		}, pb.RegisterFrontendHandlerFromEndpoint)

--- a/internal/app/minimatch/minimatch.go
+++ b/internal/app/minimatch/minimatch.go
@@ -38,7 +38,7 @@ func RunApplication() {
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
-	p, err := rpc.NewParamsFromConfig(cfg, "api.frontend")
+	p, err := rpc.NewServerParamsFromConfig(cfg, "api.frontend")
 	if err != nil {
 		minimatchLogger.WithFields(logrus.Fields{
 			"error": err.Error(),
@@ -55,7 +55,7 @@ func RunApplication() {
 }
 
 // BindService creates the minimatch service to the server Params.
-func BindService(p *rpc.Params, cfg config.View) error {
+func BindService(p *rpc.ServerParams, cfg config.View) error {
 	if err := backend.BindService(p, cfg); err != nil {
 		return err
 	}

--- a/internal/app/mmlogic/mmlogic.go
+++ b/internal/app/mmlogic/mmlogic.go
@@ -37,7 +37,7 @@ func RunApplication() {
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
-	p, err := rpc.NewParamsFromConfig(cfg, "api.mmlogic")
+	p, err := rpc.NewServerParamsFromConfig(cfg, "api.mmlogic")
 	if err != nil {
 		mmlogicLogger.WithFields(logrus.Fields{
 			"error": err.Error(),
@@ -54,7 +54,7 @@ func RunApplication() {
 }
 
 // BindService creates the mmlogic service and binds it to the serving harness.
-func BindService(p *rpc.Params, cfg config.View) error {
+func BindService(p *rpc.ServerParams, cfg config.View) error {
 	service, err := newMmlogic(cfg)
 	if err != nil {
 		return err

--- a/internal/app/mmlogic/mmlogic_test.go
+++ b/internal/app/mmlogic/mmlogic_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestServerBinding(t *testing.T) {
-	bs := func(p *rpc.Params) {
+	bs := func(p *rpc.ServerParams) {
 		p.AddHandleFunc(func(s *grpc.Server) {
 			pb.RegisterMmLogicServer(s, &mmlogicService{})
 		}, pb.RegisterMmLogicHandlerFromEndpoint)

--- a/internal/harness/golang/harness.go
+++ b/internal/harness/golang/harness.go
@@ -45,7 +45,7 @@ func RunMatchFunction(settings *FunctionSettings) {
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
-	p, err := rpc.NewParamsFromConfig(cfg, "api.functions")
+	p, err := rpc.NewServerParamsFromConfig(cfg, "api.functions")
 	if err != nil {
 		harnessLogger.WithFields(logrus.Fields{
 			"error": err.Error(),
@@ -62,7 +62,7 @@ func RunMatchFunction(settings *FunctionSettings) {
 }
 
 // BindService creates the function service to the server Params.
-func BindService(p *rpc.Params, cfg config.View, fs *FunctionSettings) error {
+func BindService(p *rpc.ServerParams, cfg config.View, fs *FunctionSettings) error {
 	service, err := newMatchFunctionService(cfg, fs)
 	if err != nil {
 		return err

--- a/internal/rpc/insecure.go
+++ b/internal/rpc/insecure.go
@@ -45,7 +45,7 @@ type insecureServer struct {
 	httpServer      *http.Server
 }
 
-func (s *insecureServer) start(params *Params) (func(), error) {
+func (s *insecureServer) start(params *ServerParams) (func(), error) {
 	s.grpcServeWaiter = make(chan error)
 	s.httpServeWaiter = make(chan error)
 	var serverStartWaiter sync.WaitGroup

--- a/internal/rpc/insecure_test.go
+++ b/internal/rpc/insecure_test.go
@@ -34,7 +34,7 @@ func TestInsecureStartStop(t *testing.T) {
 	httpLh := netlistenerTesting.MustListen()
 	ff := &shellTesting.FakeFrontend{}
 
-	params := NewParamsFromListeners(grpcLh, httpLh)
+	params := NewServerParamsFromListeners(grpcLh, httpLh)
 	params.AddHandleFunc(func(s *grpc.Server) {
 		pb.RegisterFrontendServer(s, ff)
 	}, pb.RegisterFrontendHandlerFromEndpoint)

--- a/internal/rpc/server_test.go
+++ b/internal/rpc/server_test.go
@@ -37,7 +37,7 @@ func TestStartStopServer(t *testing.T) {
 	httpLh := netlistenerTesting.MustListen()
 	ff := &shellTesting.FakeFrontend{}
 
-	params := NewParamsFromListeners(grpcLh, httpLh)
+	params := NewServerParamsFromListeners(grpcLh, httpLh)
 	params.AddHandleFunc(func(s *grpc.Server) {
 		pb.RegisterFrontendServer(s, ff)
 	}, pb.RegisterFrontendHandlerFromEndpoint)
@@ -65,7 +65,7 @@ func TestMustServeForever(t *testing.T) {
 	httpLh := netlistenerTesting.MustListen()
 	ff := &shellTesting.FakeFrontend{}
 
-	params := NewParamsFromListeners(grpcLh, httpLh)
+	params := NewServerParamsFromListeners(grpcLh, httpLh)
 	params.AddHandleFunc(func(s *grpc.Server) {
 		pb.RegisterFrontendServer(s, ff)
 	}, pb.RegisterFrontendHandlerFromEndpoint)

--- a/internal/rpc/testing/server.go
+++ b/internal/rpc/testing/server.go
@@ -23,13 +23,13 @@ import (
 	certgenTesting "open-match.dev/open-match/tools/certgen/testing"
 )
 
-// MustParamsForTesting sets up a test server in insecure-mode.
-func MustParamsForTesting() *rpc.Params {
-	return rpc.NewParamsFromListeners(netlistenerTesting.MustListen(), netlistenerTesting.MustListen())
+// MustServerParamsForTesting sets up a test server in insecure-mode.
+func MustServerParamsForTesting() *rpc.ServerParams {
+	return rpc.NewServerParamsFromListeners(netlistenerTesting.MustListen(), netlistenerTesting.MustListen())
 }
 
-// MustParamsForTestingTLS sets up a test server in TLS-mode.
-func MustParamsForTestingTLS() *rpc.Params {
+// MustServerParamsForTestingTLS sets up a test server in TLS-mode.
+func MustServerParamsForTestingTLS() *rpc.ServerParams {
 	grpcLh := netlistenerTesting.MustListen()
 	proxyLh := netlistenerTesting.MustListen()
 
@@ -37,16 +37,16 @@ func MustParamsForTestingTLS() *rpc.Params {
 	if err != nil {
 		panic(err)
 	}
-	p := rpc.NewParamsFromListeners(grpcLh, proxyLh)
+	p := rpc.NewServerParamsFromListeners(grpcLh, proxyLh)
 	p.SetTLSConfiguration(pub, pub, priv)
 
 	return p
 }
 
 // TestServerBinding verifies that a server can start and shutdown.
-func TestServerBinding(t *testing.T, binder func(*rpc.Params)) {
+func TestServerBinding(t *testing.T, binder func(*rpc.ServerParams)) {
 	assert := assert.New(t)
-	p := MustParamsForTesting()
+	p := MustServerParamsForTesting()
 	binder(p)
 	s := &rpc.Server{}
 	defer s.Stop()

--- a/internal/rpc/testing/server_test.go
+++ b/internal/rpc/testing/server_test.go
@@ -25,17 +25,17 @@ import (
 	shellTesting "open-match.dev/open-match/internal/testing"
 )
 
-// TestMustParamsForTesting verifies that a server can stand up in insecure mode.
-func TestMustParamsForTesting(t *testing.T) {
-	runServerStartStopTest(t, MustParamsForTesting())
+// TestMustServerParamsForTesting verifies that a server can stand up in insecure mode.
+func TestMustServerParamsForTesting(t *testing.T) {
+	runServerStartStopTest(t, MustServerParamsForTesting())
 }
 
-// TestMustParamsForTestingTLS verifies that a server can stand up in TLS-mode.
-func TestMustParamsForTestingTLS(t *testing.T) {
-	runServerStartStopTest(t, MustParamsForTestingTLS())
+// TestMustServerParamsForTestingTLS verifies that a server can stand up in TLS-mode.
+func TestMustServerParamsForTestingTLS(t *testing.T) {
+	runServerStartStopTest(t, MustServerParamsForTestingTLS())
 }
 
-func runServerStartStopTest(t *testing.T, p *rpc.Params) {
+func runServerStartStopTest(t *testing.T, p *rpc.ServerParams) {
 	assert := assert.New(t)
 	ff := &shellTesting.FakeFrontend{}
 	p.AddHandleFunc(func(s *grpc.Server) {

--- a/internal/rpc/tls_server.go
+++ b/internal/rpc/tls_server.go
@@ -59,7 +59,7 @@ type tlsServer struct {
 	httpServer      *http.Server
 }
 
-func (s *tlsServer) start(params *Params) (func(), error) {
+func (s *tlsServer) start(params *ServerParams) (func(), error) {
 	s.grpcServeWaiter = make(chan error)
 	s.httpServeWaiter = make(chan error)
 	var serverStartWaiter sync.WaitGroup

--- a/internal/rpc/tls_server_test.go
+++ b/internal/rpc/tls_server_test.go
@@ -95,7 +95,7 @@ func runTestStartStopTLSServer(t *testing.T, tp *tlsServerTestParams) {
 
 	ff := &shellTesting.FakeFrontend{}
 
-	serverParams := NewParamsFromListeners(tp.grpcLh, tp.proxyLh)
+	serverParams := NewServerParamsFromListeners(tp.grpcLh, tp.proxyLh)
 	serverParams.AddHandleFunc(func(s *grpc.Server) {
 		pb.RegisterFrontendServer(s, ff)
 	}, pb.RegisterFrontendHandlerFromEndpoint)


### PR DESCRIPTION
There will be a client wrapper coming in using the same Params pattern. This commit rename server related structs and functions with a 'Server' prefix to better distinguish them from the client ones.