### PR TITLE
Fail FetchMatches if match configuration is missing or unsupported

### DIFF
--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -65,6 +65,12 @@ func newBackend(cfg config.View) (*backendService, error) {
 // proposals which are then evaluated to generate results. FetchMatches method
 // streams these results back to the caller.
 func (s *backendService) FetchMatches(req *pb.FetchMatchesRequest, stream pb.Backend_FetchMatchesServer) error {
+	// Validate that the function configuration and match profiles are provided.
+	if req.Config == nil {
+		logger.Error("invalid argument, match function config is nil")
+		return status.Errorf(codes.InvalidArgument, "match function configuration needs to be provided")
+	}
+
 	ctx := stream.Context()
 	var c <-chan *pb.Match
 	switch interface{}(req.Config.Type).(type) {
@@ -85,6 +91,10 @@ func (s *backendService) FetchMatches(req *pb.FetchMatchesRequest, stream pb.Bac
 	// MatchFunction Hosted as a REST service
 	case *pb.FunctionConfig_Rest:
 		return status.Error(codes.Unimplemented, "not implemented")
+
+	default:
+		logger.Error("unsupported function type provided")
+		return status.Error(codes.InvalidArgument, "provided match function type is not supported")
 	}
 
 	for {


### PR DESCRIPTION
Add input validation to FetchMatches. The call now fails with InvalidArgument if match configuration is missing or unsupported.