### PR TITLE
Fix minor issues that were encountered in an E2E test case for generating matches.

### DIFF
--- a/internal/app/mmlogic/mmlogic_service.go
+++ b/internal/app/mmlogic/mmlogic_service.go
@@ -78,12 +78,12 @@ func (s *mmlogicService) QueryTickets(req *pb.QueryTicketsRequest, responseServe
 	}
 
 	pSize := s.cfg.GetInt("storage.page.size")
-	if pSize <= 0 {
+	if pSize < minPageSize {
 		logger.Warningf("page size %v is lower than minimum limit of %v, setting page size as %v", pSize, minPageSize, minPageSize)
 		pSize = minPageSize
 	}
 
-	if pSize > 1000 {
+	if pSize > maxPageSize {
 		logger.Warningf("page size %v is higher than maximum limit of %v, setting page size as %v", pSize, maxPageSize, maxPageSize)
 		pSize = maxPageSize
 	}

--- a/internal/harness/golang/matchfunction_service.go
+++ b/internal/harness/golang/matchfunction_service.go
@@ -146,11 +146,9 @@ func (s *matchFunctionService) getMatchManifest(ctx context.Context, req *pb.Run
 
 // TODO: replace this method once the client side wrapper is done.
 func getMMLogicClient(cfg config.View) (pb.MmLogicClient, error) {
+	// Retrieve host name and port. It is ok to not specify host name as there are scenarios
+	// where the mmlogic service will be running on the same host.
 	host := cfg.GetString("api.mmlogic.hostname")
-	if len(host) == 0 {
-		return nil, fmt.Errorf("Failed to get hostname for MMLogicAPI from the configuration")
-	}
-
 	port := cfg.GetString("api.mmlogic.grpcport")
 	if len(port) == 0 {
 		return nil, fmt.Errorf("Failed to get port for MMLogicAPI from the configuration")

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -440,7 +440,7 @@ func (rb *redisBackend) FilterTickets(ctx context.Context, filters []*pb.Filter,
 }
 
 func idsToPages(ids []string, pageSize int) [][]interface{} {
-	result := make([][]interface{}, 0, len(ids)/pageSize+1)
+	result := make([][]interface{}, 0, len(ids)/(pageSize+1))
 	for i := 0; i < len(ids); i += pageSize {
 		end := i + pageSize
 		if end > len(ids) {

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -440,7 +440,7 @@ func (rb *redisBackend) FilterTickets(ctx context.Context, filters []*pb.Filter,
 }
 
 func idsToPages(ids []string, pageSize int) [][]interface{} {
-	result := make([][]interface{}, 0, len(ids)/(pageSize+1))
+	result := make([][]interface{}, 0, len(ids)/pageSize+1)
 	for i := 0; i < len(ids); i += pageSize {
 		end := i + pageSize
 		if end > len(ids) {

--- a/internal/util/netlistener/listener_holder.go
+++ b/internal/util/netlistener/listener_holder.go
@@ -81,12 +81,10 @@ func NewFromPortNumber(portNumber int) (*ListenerHolder, error) {
 		return nil, fmt.Errorf("net.Listen(\"tcp\", %s) did not return a *net.TCPAddr", addr)
 	}
 
-	if err == nil {
-		return &ListenerHolder{
-			number:   tcpConn.Port,
-			listener: conn,
-			addr:     conn.Addr().String(),
-		}, nil
-	}
-	return nil, err
+	return &ListenerHolder{
+		number:   tcpConn.Port,
+		listener: conn,
+		addr:     conn.Addr().String(),
+	}, nil
+
 }

--- a/internal/util/netlistener/listener_holder.go
+++ b/internal/util/netlistener/listener_holder.go
@@ -72,6 +72,9 @@ func (lh *ListenerHolder) Close() error {
 func NewFromPortNumber(portNumber int) (*ListenerHolder, error) {
 	addr := fmt.Sprintf(":%d", portNumber)
 	conn, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
 
 	tcpConn, ok := conn.Addr().(*net.TCPAddr)
 	if !ok || tcpConn == nil {


### PR DESCRIPTION
Here are the issues this change fixes:

1. Add error check to avoid accessing failed connection in tcp net listener
2. Divide by zero error in the redis state storage library if page size is 0.
3. Ability to support null hostname when connecting to mmlogic client in match function harness.
4. Set min / max page size limits to initialize correctly if page size is set to unsupported values.