### PR TITLE
Add Binary Authorization commands.

### DIFF
--- a/install/policies/binauthz.yaml
+++ b/install/policies/binauthz.yaml
@@ -1,0 +1,28 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Binary Authorization Policy for Open Match Cluster
+# This policy whitelists images from well known locations and the project's images.
+admissionWhitelistPatterns:
+- namePattern: gcr.io/google_containers/*
+- namePattern: gcr.io/google-containers/*
+- namePattern: k8s.gcr.io/*
+- namePattern: gcr.io/stackdriver-agents/*
+- namePattern: gcr.io/$PROJECT_ID/*
+- namePattern: gcr.io/open-match-public-images/*
+defaultAdmissionRule:
+  # EVALUATION_MODE is either ALWAYS_DENY or ALWAYS_ALLOW based on ENABLE_SECURITY_HARDENING 
+  evaluationMode: $EVALUATION_MODE
+  enforcementMode: ENFORCED_BLOCK_AND_AUDIT_LOG
+name: projects/$PROJECT_ID/policy

--- a/site/content/en/docs/Installation/setup-gke.md
+++ b/site/content/en/docs/Installation/setup-gke.md
@@ -25,6 +25,10 @@ gcloud config set project $YOUR_GCP_PROJECT_ID
 gcloud services enable containerregistry.googleapis.com
 gcloud services enable container.googleapis.com
 
+# Enable optional GCP services for security hardening
+gcloud services enable containeranalysis.googleapis.com
+gcloud services enable binaryauthorization.googleapis.com
+
 # Test that everything is good, this command should work.
 gcloud compute zones list
 


### PR DESCRIPTION
Binary authorization adds mitigations to a GCP project from running unauthorized code. This change adds some groundwork to add an example of using binauthz for Open Match.