### PR TITLE
Hide resource closers in client/server test helpers

### DIFF
--- a/internal/rpc/testing/helpers_test.go
+++ b/internal/rpc/testing/helpers_test.go
@@ -50,7 +50,7 @@ func TestMustServeTLS(t *testing.T) {
 	runMustServeTest(t, MustServeTLS)
 }
 
-func runMustServeTest(t *testing.T, mustServeFunc func(*testing.T, func(*rpc.ServerParams)) *TestContext) {
+func runMustServeTest(t *testing.T, mustServeFunc func(*testing.T, func(*rpc.ServerParams), ...func()) *TestContext) {
 	assert := assert.New(t)
 	ff := &shellTesting.FakeFrontend{}
 	tc := mustServeFunc(t, func(spf *rpc.ServerParams) {


### PR DESCRIPTION
An attempt to write a better story for resource closers.
Binder function should only take care of binding handlers. Starting up a state store service should be moved out from the binders.