### PR TITLE
Make backoff strategy configurable

### DIFF
--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -72,18 +72,30 @@ openmatch:
           level: debug
           format: text
           source: false
+        # Open Match applies the exponential backoff strategy for its retryable gRPC calls.
+        # The settings below are the default backoff configuration used in Open Match.
+        # See https://github.com/cenkalti/backoff/blob/v3/exponential.go for detailed explanations
+        backoff:
+          # The initial retry interval (in milliseconds)
+          initialInterval: 500
+          # maxInterval caps the maximum number of retries
+          maxInterval: 3
+          # The next retry interval is multiplied by this multiplier
+          multiplier: 1.5
+          # Randomize the retry interval
+          randFactor: 0.5
+          # maxElapsedTime caps the retry time (in milliseconds)
+          maxElapsedTime: 3000
 
         api:
           backend:
             hostname: om-backend
             grpcport: "{{.Values.openmatch.backend.grpc.port}}"
             httpport: "{{.Values.openmatch.backend.http.port}}"
-            backoff: "[2 32] *2 ~0.33 <30"
           frontend:
             hostname: om-frontend
             grpcport: "{{.Values.openmatch.frontend.grpc.port}}"
             httpport: "{{.Values.openmatch.frontend.http.port}}"
-            backoff: "[2 32] *2 ~0.33 <300"
           mmlogic:
             hostname: om-mmlogic
             grpcport: "{{.Values.openmatch.mmlogic.grpc.port}}"

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -77,15 +77,15 @@ openmatch:
         # See https://github.com/cenkalti/backoff/blob/v3/exponential.go for detailed explanations
         backoff:
           # The initial retry interval (in milliseconds)
-          initialInterval: 500
-          # maxInterval caps the maximum number of retries
-          maxInterval: 3
+          initialInterval: 100ms
+          # maxInterval caps the maximum time elapsed for a retry interval
+          maxInterval: 500ms
           # The next retry interval is multiplied by this multiplier
           multiplier: 1.5
           # Randomize the retry interval
           randFactor: 0.5
           # maxElapsedTime caps the retry time (in milliseconds)
-          maxElapsedTime: 3000
+          maxElapsedTime: 3000ms
 
         api:
           backend:

--- a/internal/config/view.go
+++ b/internal/config/view.go
@@ -27,6 +27,7 @@ type View interface {
 	GetString(string) string
 	GetInt(string) int
 	GetInt64(string) int64
+	GetFloat64(string) float64
 	GetStringSlice(string) []string
 	GetBool(string) bool
 	GetDuration(string) time.Duration

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -586,10 +586,10 @@ func handleConnectionClose(conn *redis.Conn) {
 // TODO: add cache the backoff object
 func (rb *redisBackend) createBackoffStrat() backoff.BackOff {
 	backoffStrat := backoff.NewExponentialBackOff()
-	backoffStrat.InitialInterval = rb.cfg.GetDuration("backoff.initialInterval") * time.Millisecond
+	backoffStrat.InitialInterval = rb.cfg.GetDuration("backoff.initialInterval")
 	backoffStrat.RandomizationFactor = rb.cfg.GetFloat64("backoff.randFactor")
 	backoffStrat.Multiplier = rb.cfg.GetFloat64("backoff.multiplier")
 	backoffStrat.MaxInterval = rb.cfg.GetDuration("backoff.maxInterval")
-	backoffStrat.InitialInterval = rb.cfg.GetDuration("backoff.maxElapsedTime") * time.Millisecond
+	backoffStrat.MaxElapsedTime = rb.cfg.GetDuration("backoff.maxElapsedTime")
 	return backoff.BackOff(backoffStrat)
 }

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -548,20 +548,13 @@ func (rb *redisBackend) GetAssignments(ctx context.Context, id string, callback 
 		if err != nil {
 			return backoff.Permanent(err)
 		}
-
 		return nil
 	}
 
-	// TODO: make max retries configurable
-	err = backoff.Retry(
-		backoffOperation,
-		backoff.WithMaxRetries(backoff.NewExponentialBackOff(), 3),
-	)
-
+	err = backoff.Retry(backoffOperation, rb.createBackoffStrat())
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -588,4 +581,15 @@ func handleConnectionClose(conn *redis.Conn) {
 			"error": err,
 		}).Debug("failed to close redis client connection.")
 	}
+}
+
+// TODO: add cache the backoff object
+func (rb *redisBackend) createBackoffStrat() backoff.BackOff {
+	backoffStrat := backoff.NewExponentialBackOff()
+	backoffStrat.InitialInterval = rb.cfg.GetDuration("backoff.initialInterval") * time.Millisecond
+	backoffStrat.RandomizationFactor = rb.cfg.GetFloat64("backoff.randFactor")
+	backoffStrat.Multiplier = rb.cfg.GetFloat64("backoff.multiplier")
+	backoffStrat.MaxInterval = rb.cfg.GetDuration("backoff.maxInterval")
+	backoffStrat.InitialInterval = rb.cfg.GetDuration("backoff.maxElapsedTime") * time.Millisecond
+	return backoff.BackOff(backoffStrat)
 }

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -255,11 +255,11 @@ func createRedis(t *testing.T) config.View {
 	cfg.Set("redis.pool.idleTimeout", time.Second)
 	cfg.Set("redis.pool.maxActive", 1000)
 	cfg.Set("redis.expiration", 42000)
-	cfg.Set("backoff.initialInterval", 500*time.Millisecond)
+	cfg.Set("backoff.initialInterval", 100*time.Millisecond)
 	cfg.Set("backoff.randFactor", 0.5)
 	cfg.Set("backoff.multiplier", 0.5)
-	cfg.Set("backoff.maxInterval", 3)
-	cfg.Set("backoff.maxElapsedTime", 3000*time.Millisecond)
+	cfg.Set("backoff.maxInterval", 300*time.Millisecond)
+	cfg.Set("backoff.maxElapsedTime", 100*time.Millisecond)
 	cfg.Set("playerIndices", []string{"testindex1", "testindex2"})
 
 	return cfg

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -255,6 +255,11 @@ func createRedis(t *testing.T) config.View {
 	cfg.Set("redis.pool.idleTimeout", time.Second)
 	cfg.Set("redis.pool.maxActive", 1000)
 	cfg.Set("redis.expiration", 42000)
+	cfg.Set("backoff.initialInterval", 500*time.Millisecond)
+	cfg.Set("backoff.randFactor", 0.5)
+	cfg.Set("backoff.multiplier", 0.5)
+	cfg.Set("backoff.maxInterval", 3)
+	cfg.Set("backoff.maxElapsedTime", 3000*time.Millisecond)
 	cfg.Set("playerIndices", []string{"testindex1", "testindex2"})
 
 	return cfg


### PR DESCRIPTION
open match v.5's backoff config is a bit unnatural. This commit aims to make config easier to understand and configurable.